### PR TITLE
Add asset pallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev": "vitest dev",
     "lint": "eslint --fix --ext .ts,.js,.mjs,.cjs .",
     "prepack": "unbuild",
+    "updateAssets": "node --loader ts-node/esm --experimental-specifier-resolution=node ./src/scripts/updateAssets.ts",
     "release": "pnpm test && standard-version && git push --follow-tags && pnpm publish --no-git-checks --access=public",
     "test": "pnpm lint && vitest run --coverage"
   },
@@ -35,9 +36,11 @@
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "latest",
+    "@types/node": "^18.11.9",
     "@vitest/coverage-c8": "latest",
     "eslint": "latest",
     "standard-version": "latest",
+    "ts-node": "^10.9.1",
     "typescript": "latest",
     "unbuild": "latest",
     "vitest": "latest"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,12 @@ specifiers:
   '@polkadot/apps-config': ^0.122.2
   '@polkadot/types': ^8.0.2
   '@polkadot/util-crypto': ^10.1.11
+  '@types/node': ^18.11.9
   '@vitest/coverage-c8': latest
   eslint: latest
   ethers: ^5.7.1
   standard-version: latest
+  ts-node: ^10.9.1
   typescript: latest
   unbuild: latest
   vitest: latest
@@ -22,13 +24,15 @@ dependencies:
   ethers: 5.7.1
 
 devDependencies:
-  '@nuxtjs/eslint-config-typescript': 11.0.0_rmayb2veg2btbq6mbmnyivgasy
-  '@vitest/coverage-c8': 0.25.1
-  eslint: 8.27.0
+  '@nuxtjs/eslint-config-typescript': 12.0.0_hsf322ms6xhhd4b5ne6lb74y4a
+  '@types/node': 18.11.9
+  '@vitest/coverage-c8': 0.25.2
+  eslint: 8.28.0
   standard-version: 9.5.0
-  typescript: 4.8.4
-  unbuild: 0.9.4
-  vitest: 0.25.1
+  ts-node: 10.9.1_wup25etrarvlqkprac7h35hj7u
+  typescript: 4.9.3
+  unbuild: 1.0.1
+  vitest: 0.25.2
 
 packages:
 
@@ -53,25 +57,25 @@ packages:
       '@babel/highlight': 7.18.6
     dev: true
 
-  /@babel/compat-data/7.19.3:
-    resolution: {integrity: sha512-prBHMK4JYYK+wDjJF1q99KK4JLL+egWS4nmNqdlMUgCExMZ+iZW0hGhyC3VEbsPjvaN0TBhW//VIFwBrk8sEiw==}
+  /@babel/compat-data/7.20.1:
+    resolution: {integrity: sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core/7.19.3:
-    resolution: {integrity: sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==}
+  /@babel/core/7.20.2:
+    resolution: {integrity: sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.19.3
-      '@babel/helper-compilation-targets': 7.19.3_@babel+core@7.19.3
-      '@babel/helper-module-transforms': 7.19.0
-      '@babel/helpers': 7.19.0
-      '@babel/parser': 7.19.3
+      '@babel/generator': 7.20.4
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.2
+      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helpers': 7.20.1
+      '@babel/parser': 7.20.3
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.3
-      '@babel/types': 7.19.3
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -81,23 +85,23 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/generator/7.19.3:
-    resolution: {integrity: sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==}
+  /@babel/generator/7.20.4:
+    resolution: {integrity: sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.20.2
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
     dev: true
 
-  /@babel/helper-compilation-targets/7.19.3_@babel+core@7.19.3:
-    resolution: {integrity: sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==}
+  /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.2:
+    resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.19.3
-      '@babel/core': 7.19.3
+      '@babel/compat-data': 7.20.1
+      '@babel/core': 7.20.2
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.3
       semver: 6.3.0
@@ -113,55 +117,55 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.19.3
+      '@babel/types': 7.20.2
     dev: true
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.20.2
     dev: true
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.20.2
     dev: true
 
-  /@babel/helper-module-transforms/7.19.0:
-    resolution: {integrity: sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==}
+  /@babel/helper-module-transforms/7.20.2:
+    resolution: {integrity: sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-simple-access': 7.18.6
+      '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.3
-      '@babel/types': 7.19.3
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-simple-access/7.18.6:
-    resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
+  /@babel/helper-simple-access/7.20.2:
+    resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.20.2
     dev: true
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.20.2
     dev: true
 
-  /@babel/helper-string-parser/7.18.10:
-    resolution: {integrity: sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==}
+  /@babel/helper-string-parser/7.19.4:
+    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -175,13 +179,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helpers/7.19.0:
-    resolution: {integrity: sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==}
+  /@babel/helpers/7.20.1:
+    resolution: {integrity: sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.3
-      '@babel/types': 7.19.3
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -195,12 +199,12 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/parser/7.19.3:
-    resolution: {integrity: sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==}
+  /@babel/parser/7.20.3:
+    resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.20.2
     dev: true
 
   /@babel/runtime/7.19.0:
@@ -217,8 +221,8 @@ packages:
       regenerator-runtime: 0.13.10
     dev: false
 
-  /@babel/standalone/7.19.3:
-    resolution: {integrity: sha512-zSdDx28L6f27Y59OMrl8mBbtyB/cpIGlHm7wVOHlcmUTpD10AiUILkekZATkkpsuTagTWezdJmUaeY8P2SONUA==}
+  /@babel/standalone/7.20.4:
+    resolution: {integrity: sha512-27bv4h47jbaFZ7+e7gT1VEo9PNL1ynxqUX6/BERLz1qxm/5gzpbcHX+47VnSeYHyEyGZkRznpSOd8zPBhiz6tw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -227,33 +231,33 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.19.3
-      '@babel/types': 7.19.3
+      '@babel/parser': 7.20.3
+      '@babel/types': 7.20.2
     dev: true
 
-  /@babel/traverse/7.19.3:
-    resolution: {integrity: sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==}
+  /@babel/traverse/7.20.1:
+    resolution: {integrity: sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.19.3
+      '@babel/generator': 7.20.4
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.19.3
-      '@babel/types': 7.19.3
+      '@babel/parser': 7.20.3
+      '@babel/types': 7.20.2
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/types/7.19.3:
-    resolution: {integrity: sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==}
+  /@babel/types/7.20.2:
+    resolution: {integrity: sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.18.10
+      '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
     dev: true
@@ -273,6 +277,13 @@ packages:
     dependencies:
       '@open-web3/orml-type-definitions': 0.9.4-38
     dev: false
+
+  /@cspotcode/source-map-support/0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
 
   /@darwinia/types-known/2.8.10:
     resolution: {integrity: sha512-bdNzf1gOw0is3PvcQJXkjf5jp8j0pT0wDxamkwLdajMymWgi0cReReDlhmGNx4Qvq6gy3TVJ9aok0Nsrr4sjKg==}
@@ -306,8 +317,8 @@ packages:
     resolution: {integrity: sha512-F8jDESrhUpapqGSTXWND+5/DOqFlnh/oEejIYVIzF2WeUreHJzUPpI8a8Hb9plCLxj5sxYJ+3JL/5epMcrXDaQ==}
     dev: false
 
-  /@esbuild/android-arm/0.15.13:
-    resolution: {integrity: sha512-RY2fVI8O0iFUNvZirXaQ1vMvK0xhCcl0gqRj74Z6yEiO1zAUa7hbsdwZM1kzqbxHK7LFyMizipfXT3JME+12Hw==}
+  /@esbuild/android-arm/0.15.14:
+    resolution: {integrity: sha512-+Rb20XXxRGisNu2WmNKk+scpanb7nL5yhuI1KR9wQFiC43ddPj/V1fmNyzlFC9bKiG4mYzxW7egtoHVcynr+OA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -324,8 +335,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64/0.15.13:
-    resolution: {integrity: sha512-+BoyIm4I8uJmH/QDIH0fu7MG0AEx9OXEDXnqptXCwKOlOqZiS4iraH1Nr7/ObLMokW3sOCeBNyD68ATcV9b9Ag==}
+  /@esbuild/linux-loong64/0.15.14:
+    resolution: {integrity: sha512-eQi9rosGNVQFJyJWV0HCA5WZae/qWIQME7s8/j8DMvnylfBv62Pbu+zJ2eUDqNf2O4u3WB+OEXyfkpBoe194sg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -737,6 +748,13 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
+  /@jridgewell/trace-mapping/0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
   /@kiltprotocol/type-definitions/0.2.1:
     resolution: {integrity: sha512-By09MH20P+rXadiZDnw2XeAw7bQLgNazOyNS3gPdU1L4Jx+lU9OtvIgZEA+T/TY/KM5nTv32s3c4wZ7v1s2znw==}
     dev: false
@@ -810,36 +828,38 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@nuxtjs/eslint-config-typescript/11.0.0_rmayb2veg2btbq6mbmnyivgasy:
-    resolution: {integrity: sha512-hmFjGtXT524ql8eTbK8BaRkamcXB6Z8YOW8nSQhosTP6oBw9WtOFUeWr7holyE278UhOmx+wDFG90BnyM9D+UA==}
+  /@nuxtjs/eslint-config-typescript/12.0.0_hsf322ms6xhhd4b5ne6lb74y4a:
+    resolution: {integrity: sha512-HJR0ho5MYuOCFjkL+eMX/VXbUwy36J12DUMVy+dj3Qz1GYHwX92Saxap3urFzr8oPkzzFiuOknDivfCeRBWakg==}
     peerDependencies:
       eslint: ^8.23.0
     dependencies:
-      '@nuxtjs/eslint-config': 11.0.0_ankxupw42u6sowqa4gjcxemuni
-      '@typescript-eslint/eslint-plugin': 5.36.1_ptjtm5ueew7d66dpdptn6han3m
-      '@typescript-eslint/parser': 5.36.1_rmayb2veg2btbq6mbmnyivgasy
-      eslint: 8.27.0
-      eslint-import-resolver-typescript: 3.5.0_dcpv4nbdr5ks2h5677xdltrk6e
-      eslint-plugin-import: 2.26.0_ankxupw42u6sowqa4gjcxemuni
+      '@nuxtjs/eslint-config': 12.0.0_d5vn4nsvkp5ugznurcfxmdkaeu
+      '@typescript-eslint/eslint-plugin': 5.43.0_nqj4bdx4ekws7aecttskpih4py
+      '@typescript-eslint/parser': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
+      eslint: 8.28.0
+      eslint-import-resolver-typescript: 3.5.2_ktrec6dplf4now6nlbc6d67jee
+      eslint-plugin-import: 2.26.0_d5vn4nsvkp5ugznurcfxmdkaeu
+      eslint-plugin-vue: 9.7.0_eslint@8.28.0
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
 
-  /@nuxtjs/eslint-config/11.0.0_ankxupw42u6sowqa4gjcxemuni:
-    resolution: {integrity: sha512-o4zFOpU8gJgwrC/gLE7c2E0XEjkv2fEixCGG1y+dZYzBPyzTorkQmfxskSF3WRXcZkpkS9uUYlRkeOSdYB7z0w==}
+  /@nuxtjs/eslint-config/12.0.0_d5vn4nsvkp5ugznurcfxmdkaeu:
+    resolution: {integrity: sha512-ewenelo75x0eYEUK+9EBXjc/OopQCvdkmYmlZuoHq5kub/vtiRpyZ/autppwokpHUq8tiVyl2ejMakoiHiDTrg==}
     peerDependencies:
       eslint: ^8.23.0
     dependencies:
-      eslint: 8.27.0
-      eslint-config-standard: 17.0.0_yqvjeq2xzul43p26zlvfoiu3rm
-      eslint-plugin-import: 2.26.0_ankxupw42u6sowqa4gjcxemuni
-      eslint-plugin-n: 15.2.5_eslint@8.27.0
-      eslint-plugin-node: 11.1.0_eslint@8.27.0
-      eslint-plugin-promise: 6.0.1_eslint@8.27.0
-      eslint-plugin-unicorn: 43.0.2_eslint@8.27.0
-      eslint-plugin-vue: 9.4.0_eslint@8.27.0
+      eslint: 8.28.0
+      eslint-config-standard: 17.0.0_5dakk4wnrkkieagghiqvu5yn4y
+      eslint-plugin-import: 2.26.0_d5vn4nsvkp5ugznurcfxmdkaeu
+      eslint-plugin-n: 15.5.1_eslint@8.28.0
+      eslint-plugin-node: 11.1.0_eslint@8.28.0
+      eslint-plugin-promise: 6.1.1_eslint@8.28.0
+      eslint-plugin-unicorn: 44.0.2_eslint@8.28.0
+      eslint-plugin-vue: 9.7.0_eslint@8.28.0
+      local-pkg: 0.4.2
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-typescript
@@ -939,6 +959,23 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@polkadot/api-augment/9.9.1:
+    resolution: {integrity: sha512-0HS6Kit9ZiO2iQU/aS/jpOjXl9rFcwW6FdUs1eSXvWjvAFpoxwCMG8bv8wVjNZcCUuA2w5U0+2B+Xa612QEQQg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/api-base': 9.9.1
+      '@polkadot/rpc-augment': 9.9.1
+      '@polkadot/types': 9.9.1
+      '@polkadot/types-augment': 9.9.1
+      '@polkadot/types-codec': 9.9.1
+      '@polkadot/util': 10.1.13
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /@polkadot/api-base/7.15.1:
     resolution: {integrity: sha512-UlhLdljJPDwGpm5FxOjvJNFTxXMRFaMuVNx6EklbuetbBEJ/Amihhtj0EJRodxQwtZ4ZtPKYKt+g+Dn7OJJh4g==}
     engines: {node: '>=14.0.0'}
@@ -974,6 +1011,21 @@ packages:
       '@polkadot/rpc-core': 9.8.1
       '@polkadot/types': 9.8.1
       '@polkadot/util': 10.1.12
+      rxjs: 7.5.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /@polkadot/api-base/9.9.1:
+    resolution: {integrity: sha512-uJDLi+nHQ08QZ+p1ldzwMeNjCyIkpR1DOzvKV3M3bLepglF8r7V/7W5dXk+qlClMqgB92RgKwo4R6EPRgr5BcA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/rpc-core': 9.9.1
+      '@polkadot/types': 9.9.1
+      '@polkadot/util': 10.1.13
       rxjs: 7.5.7
     transitivePeerDependencies:
       - bufferutil
@@ -1031,6 +1083,26 @@ packages:
       '@polkadot/types-codec': 9.8.1
       '@polkadot/util': 10.1.12
       '@polkadot/util-crypto': 10.1.12_@polkadot+util@10.1.12
+      rxjs: 7.5.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /@polkadot/api-derive/9.9.1:
+    resolution: {integrity: sha512-cCCbnhXfCo9Mj4DCM0TVoDOEe5yleOLdqoICU9T4PMv5R51D+iMmw97+MYCgyjRdm7wIW05LlW32iUVrgDiSJw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/api': 9.9.1
+      '@polkadot/api-augment': 9.9.1
+      '@polkadot/api-base': 9.9.1
+      '@polkadot/rpc-core': 9.9.1
+      '@polkadot/types': 9.9.1
+      '@polkadot/types-codec': 9.9.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/util-crypto': 10.1.13_@polkadot+util@10.1.13
       rxjs: 7.5.7
     transitivePeerDependencies:
       - bufferutil
@@ -1116,6 +1188,33 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@polkadot/api/9.9.1:
+    resolution: {integrity: sha512-3ltj6BbqEV9SCUlJIEmXWBmmQlZCvVPaj0N+99J9L2yiQ1E0KJsAizh10RxEjCvgYb2iWaE4ItPfhN0GxFJm7Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/api-augment': 9.9.1
+      '@polkadot/api-base': 9.9.1
+      '@polkadot/api-derive': 9.9.1
+      '@polkadot/keyring': 10.1.13_mzup5jnxcpjb2nlyioiahww73y
+      '@polkadot/rpc-augment': 9.9.1
+      '@polkadot/rpc-core': 9.9.1
+      '@polkadot/rpc-provider': 9.9.1
+      '@polkadot/types': 9.9.1
+      '@polkadot/types-augment': 9.9.1
+      '@polkadot/types-codec': 9.9.1
+      '@polkadot/types-create': 9.9.1
+      '@polkadot/types-known': 9.9.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/util-crypto': 10.1.13_@polkadot+util@10.1.13
+      eventemitter3: 4.0.7
+      rxjs: 7.5.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /@polkadot/apps-config/0.122.2_uuutczr247ytacyuc6mal3fii4:
     resolution: {integrity: sha512-EBINVhOe4w5gzjOJ/lIzYJDP1DiZY8SWBf8Jp25DOwdSvUsyV1AYyrGAgmz+kE+jtakEMKOZpXdRt3OwGYLPqw==}
     dependencies:
@@ -1139,7 +1238,7 @@ packages:
       '@phala/typedefs': 0.2.32
       '@polkadot/api': 9.8.1
       '@polkadot/api-derive': 9.8.1
-      '@polkadot/networks': 10.1.11
+      '@polkadot/networks': 10.1.12
       '@polkadot/types': 9.8.1
       '@polkadot/util': 10.1.11
       '@polkadot/x-fetch': 10.1.12
@@ -1174,6 +1273,18 @@ packages:
       '@babel/runtime': 7.20.1
       '@polkadot/util': 10.1.12
       '@polkadot/util-crypto': 10.1.12_@polkadot+util@10.1.12
+    dev: false
+
+  /@polkadot/keyring/10.1.13_mzup5jnxcpjb2nlyioiahww73y:
+    resolution: {integrity: sha512-O5/sM1cfn/ueT7C6sxqZI9Z18RLOpPovdfZzBlcRAyfs/8uR+UA20r2lGCQdQIzlOeF0XPebIO0lwW+6wPtvtg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@polkadot/util': 10.1.13
+      '@polkadot/util-crypto': 10.1.13
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/util-crypto': 10.1.13_@polkadot+util@10.1.13
     dev: false
 
   /@polkadot/keyring/10.1.7_uuutczr247ytacyuc6mal3fii4:
@@ -1264,6 +1375,15 @@ packages:
       '@substrate/ss58-registry': 1.34.0
     dev: false
 
+  /@polkadot/networks/10.1.13:
+    resolution: {integrity: sha512-EvR0weOZlTS9AzQd8/s7WJrLCfAdaP3fKPSoaJkir1fUrpmhagMZaIm+kHmKO3lqEaqV+EAZm3Ee43bZN0na7A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
+      '@substrate/ss58-registry': 1.34.0
+    dev: false
+
   /@polkadot/networks/6.11.1:
     resolution: {integrity: sha512-0C6Ha2kvr42se3Gevx6UhHzv3KnPHML0N73Amjwvdr4y0HLZ1Nfw+vcm5yqpz5gpiehqz97XqFrsPRauYdcksQ==}
     engines: {node: '>=14.0.0'}
@@ -1322,6 +1442,21 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@polkadot/rpc-augment/9.9.1:
+    resolution: {integrity: sha512-t3gTendxM9KD9Sg+hT7Wn72Xdusl25EsXcdOjFqQWUtFL8xjYcFngrTTifG90e+ciFIk1DWps2+zc6lbDwBfeA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/rpc-core': 9.9.1
+      '@polkadot/types': 9.9.1
+      '@polkadot/types-codec': 9.9.1
+      '@polkadot/util': 10.1.13
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /@polkadot/rpc-core/7.15.1:
     resolution: {integrity: sha512-4Sb0e0PWmarCOizzxQAE1NQSr5z0n+hdkrq3+aPohGu9Rh4PodG+OWeIBy7Ov/3GgdhNQyBLG+RiVtliXecM3g==}
     engines: {node: '>=14.0.0'}
@@ -1360,6 +1495,22 @@ packages:
       '@polkadot/rpc-provider': 9.8.1
       '@polkadot/types': 9.8.1
       '@polkadot/util': 10.1.12
+      rxjs: 7.5.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /@polkadot/rpc-core/9.9.1:
+    resolution: {integrity: sha512-ij1OxDfbPpdZ9+aN8oicZrysIfUjC7INBhDwwoZ4R/4jhqJvIV1fisgj6XOdHGlZGl+vQBnObOw0nEOU7apdQg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/rpc-augment': 9.9.1
+      '@polkadot/rpc-provider': 9.9.1
+      '@polkadot/types': 9.9.1
+      '@polkadot/util': 10.1.13
       rxjs: 7.5.7
     transitivePeerDependencies:
       - bufferutil
@@ -1433,6 +1584,29 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@polkadot/rpc-provider/9.9.1:
+    resolution: {integrity: sha512-YyIwYDAgeEAAjvsH/v5v6sFkhkoaER98rPIcfP+81sGcxpjBCArg4feDtzTPQMsnUcbj3708ppJicu6ECc1xFg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/keyring': 10.1.13_mzup5jnxcpjb2nlyioiahww73y
+      '@polkadot/types': 9.9.1
+      '@polkadot/types-support': 9.9.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/util-crypto': 10.1.13_@polkadot+util@10.1.13
+      '@polkadot/x-fetch': 10.1.13
+      '@polkadot/x-global': 10.1.13
+      '@polkadot/x-ws': 10.1.13
+      '@substrate/connect': 0.7.17
+      eventemitter3: 4.0.7
+      mock-socket: 9.1.5
+      nock: 13.2.9
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /@polkadot/types-augment/7.15.1:
     resolution: {integrity: sha512-aqm7xT/66TCna0I2utpIekoquKo0K5pnkA/7WDzZ6gyD8he2h0IXfe8xWjVmuyhjxrT/C/7X1aUF2Z0xlOCwzQ==}
     engines: {node: '>=14.0.0'}
@@ -1463,6 +1637,16 @@ packages:
       '@polkadot/util': 10.1.12
     dev: false
 
+  /@polkadot/types-augment/9.9.1:
+    resolution: {integrity: sha512-h4DhtVPbe7/6Mdwickqih3ltvEV9y08a8LVvjxVVaGw1gRcoQpcMLkvsyWh5caYBPCKuJvXV40p4PnvO/HtW2A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/types': 9.9.1
+      '@polkadot/types-codec': 9.9.1
+      '@polkadot/util': 10.1.13
+    dev: false
+
   /@polkadot/types-codec/7.15.1:
     resolution: {integrity: sha512-nI11dT7FGaeDd/fKPD8iJRFGhosOJoyjhZ0gLFFDlKCaD3AcGBRTTY8HFJpP/5QXXhZzfZsD93fVKrosnegU0Q==}
     engines: {node: '>=14.0.0'}
@@ -1487,6 +1671,15 @@ packages:
       '@babel/runtime': 7.20.1
       '@polkadot/util': 10.1.12
       '@polkadot/x-bigint': 10.1.12
+    dev: false
+
+  /@polkadot/types-codec/9.9.1:
+    resolution: {integrity: sha512-vBzInneVp2ClDD/bmrf9HUp9La0udBJnhvyqwdLA2IKQBjIYOxVtuC62D4dg1Svp34NH4+b/nAtWlOvflSjOQQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/x-bigint': 10.1.13
     dev: false
 
   /@polkadot/types-create/7.15.1:
@@ -1514,6 +1707,15 @@ packages:
       '@babel/runtime': 7.20.1
       '@polkadot/types-codec': 9.8.1
       '@polkadot/util': 10.1.12
+    dev: false
+
+  /@polkadot/types-create/9.9.1:
+    resolution: {integrity: sha512-fzHTdWdXPbJxAYNP2nFzM9B1Nom7wiIFalltIj3jLQYF8uCgPuMF4/nLDi5uEg5YpCBCTagqyoVUuEd4riDS/Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/types-codec': 9.9.1
+      '@polkadot/util': 10.1.13
     dev: false
 
   /@polkadot/types-known/4.17.1:
@@ -1553,7 +1755,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@babel/runtime': 7.20.1
-      '@polkadot/networks': 10.1.11
+      '@polkadot/networks': 10.1.12
       '@polkadot/types': 8.14.1
       '@polkadot/types-codec': 8.14.1
       '@polkadot/types-create': 8.14.1
@@ -1570,6 +1772,18 @@ packages:
       '@polkadot/types-codec': 9.8.1
       '@polkadot/types-create': 9.8.1
       '@polkadot/util': 10.1.12
+    dev: false
+
+  /@polkadot/types-known/9.9.1:
+    resolution: {integrity: sha512-kD51etsC0Oh5RnBTVabxmIqXe03XRYBDAaaC6yj2MGiPsyuy3X6g26xPZy9pSYcjkkWIF81CtPcLaJE5YrG0/A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/networks': 10.1.13
+      '@polkadot/types': 9.9.1
+      '@polkadot/types-codec': 9.9.1
+      '@polkadot/types-create': 9.9.1
+      '@polkadot/util': 10.1.13
     dev: false
 
   /@polkadot/types-support/7.15.1:
@@ -1594,6 +1808,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.1
       '@polkadot/util': 10.1.12
+    dev: false
+
+  /@polkadot/types-support/9.9.1:
+    resolution: {integrity: sha512-PGu80mMvyr+rD6pi8Z/r9l650cadpW4X+pWt4tJnKYAbtiaE9mQJGFwq+HgY3vExzRDhaXNOUDg9d1ry5XUvJQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
     dev: false
 
   /@polkadot/types/4.17.1:
@@ -1660,6 +1882,20 @@ packages:
       rxjs: 7.5.7
     dev: false
 
+  /@polkadot/types/9.9.1:
+    resolution: {integrity: sha512-WK0CPj0LZhb5ZSfhMvT5ZZv0nnqz9wQdRSehjqeuq7DD2TgTIPZL22zP4UjJPAJEyTtwyfcRn6+ZhL2JS5w0Jg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/keyring': 10.1.13_mzup5jnxcpjb2nlyioiahww73y
+      '@polkadot/types-augment': 9.9.1
+      '@polkadot/types-codec': 9.9.1
+      '@polkadot/types-create': 9.9.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/util-crypto': 10.1.13_@polkadot+util@10.1.13
+      rxjs: 7.5.7
+    dev: false
+
   /@polkadot/util-crypto/10.1.11:
     resolution: {integrity: sha512-wG63frIMAR5T/HXGM0SFNzZZdk7qDBsfLXfn6PIZiXCCCsdEYPzS5WltB7fkhicYpbePJ7VgdCAddj1l4IcGyg==}
     engines: {node: '>=14.0.0'}
@@ -1691,6 +1927,25 @@ packages:
       '@polkadot/wasm-crypto': 6.3.1_klobyzdarg25uad6uqq67z6rye
       '@polkadot/x-bigint': 10.1.12
       '@polkadot/x-randomvalues': 10.1.12
+      '@scure/base': 1.1.1
+      ed2curve: 0.3.0
+      tweetnacl: 1.0.3
+    dev: false
+
+  /@polkadot/util-crypto/10.1.13_@polkadot+util@10.1.13:
+    resolution: {integrity: sha512-LYHsJM8hzsvehO2T1S5vMFX7k2gCt/QnG3NzSGo+97OauitrICN8V7py4o5TOewUzMeihNMVKjRkj/cC4e+i4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@polkadot/util': 10.1.13
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@noble/hashes': 1.1.3
+      '@noble/secp256k1': 1.7.0
+      '@polkadot/networks': 10.1.13
+      '@polkadot/util': 10.1.13
+      '@polkadot/wasm-crypto': 6.3.1_nz7hxxoej7rhwtqhu42recmbci
+      '@polkadot/x-bigint': 10.1.13
+      '@polkadot/x-randomvalues': 10.1.13
       '@scure/base': 1.1.1
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
@@ -1765,6 +2020,19 @@ packages:
       bn.js: 5.2.1
     dev: false
 
+  /@polkadot/util/10.1.13:
+    resolution: {integrity: sha512-wedd6NKIA1gKUm21SFwsq8UzQrMAzc2fBjrfD07LIXEJ2S/q5IKF57NjGMzf6fdNFt0376VNLUGD4MbxSc9/HA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/x-bigint': 10.1.13
+      '@polkadot/x-global': 10.1.13
+      '@polkadot/x-textdecoder': 10.1.13
+      '@polkadot/x-textencoder': 10.1.13
+      '@types/bn.js': 5.1.1
+      bn.js: 5.2.1
+    dev: false
+
   /@polkadot/util/10.1.7:
     resolution: {integrity: sha512-s7gDLdNb4HUpoe3faXwoO6HwiUp8pi66voYKiUYRh1kEtW1o9vGBgyZPHPGC/FBgILzTJKii/9XxnSex60zBTA==}
     engines: {node: '>=14.0.0'}
@@ -1829,6 +2097,18 @@ packages:
       '@polkadot/x-randomvalues': 10.1.11
     dev: false
 
+  /@polkadot/wasm-bridge/6.3.1_nz7hxxoej7rhwtqhu42recmbci:
+    resolution: {integrity: sha512-1TYkHsb9AEFhU9uZj3biEnN2yKQNzdrwSjiTvfCYnt97pnEkKsZI6cku+YPZQv5w/x9CQa5Yua9e2DVVZSivGA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/x-randomvalues': 10.1.13
+    dev: false
+
   /@polkadot/wasm-crypto-asmjs/4.6.1_@polkadot+util@6.11.1:
     resolution: {integrity: sha512-1oHQjz2oEO1kCIcQniOP+dZ9N2YXf2yCLHLsKaKSvfXiWaetVCaBNB8oIHIVYvuLnVc8qlMi66O6xc1UublHsw==}
     engines: {node: '>=14.0.0'}
@@ -1869,6 +2149,16 @@ packages:
       '@polkadot/util': 10.1.12
     dev: false
 
+  /@polkadot/wasm-crypto-asmjs/6.3.1_@polkadot+util@10.1.13:
+    resolution: {integrity: sha512-zbombRfA5v/mUWQQhgg2YwaxhRmxRIrvskw65x+lruax3b6xPBFDs7yplopiJU3r8h2pTgQvX/DUksvqz2TCRQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@polkadot/util': '*'
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
+    dev: false
+
   /@polkadot/wasm-crypto-init/6.3.1_klobyzdarg25uad6uqq67z6rye:
     resolution: {integrity: sha512-9yaUBcu+snwjJLmPPGl3cyGRQ1afyFGm16qzTM0sgG/ZCfUlK4uk8KWZe+sBUKgoxb2oXY7Y4WklKgQI1YBdfw==}
     engines: {node: '>=14.0.0'}
@@ -1897,6 +2187,21 @@ packages:
       '@polkadot/wasm-crypto-asmjs': 6.3.1_@polkadot+util@10.1.11
       '@polkadot/wasm-crypto-wasm': 6.3.1_@polkadot+util@10.1.11
       '@polkadot/x-randomvalues': 10.1.11
+    dev: false
+
+  /@polkadot/wasm-crypto-init/6.3.1_nz7hxxoej7rhwtqhu42recmbci:
+    resolution: {integrity: sha512-9yaUBcu+snwjJLmPPGl3cyGRQ1afyFGm16qzTM0sgG/ZCfUlK4uk8KWZe+sBUKgoxb2oXY7Y4WklKgQI1YBdfw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/wasm-bridge': 6.3.1_nz7hxxoej7rhwtqhu42recmbci
+      '@polkadot/wasm-crypto-asmjs': 6.3.1_@polkadot+util@10.1.13
+      '@polkadot/wasm-crypto-wasm': 6.3.1_@polkadot+util@10.1.13
+      '@polkadot/x-randomvalues': 10.1.13
     dev: false
 
   /@polkadot/wasm-crypto-wasm/4.6.1_@polkadot+util@6.11.1:
@@ -1939,6 +2244,17 @@ packages:
       '@babel/runtime': 7.20.1
       '@polkadot/util': 10.1.12
       '@polkadot/wasm-util': 6.3.1_@polkadot+util@10.1.12
+    dev: false
+
+  /@polkadot/wasm-crypto-wasm/6.3.1_@polkadot+util@10.1.13:
+    resolution: {integrity: sha512-idSlzKGVzCfeCMRHsacRvqwojSaTadFxL/Dbls4z1thvfa3U9Ku0d2qVtlwg7Hj+tYWDiuP8Kygs+6bQwfs0XA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@polkadot/util': '*'
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/wasm-util': 6.3.1_@polkadot+util@10.1.13
     dev: false
 
   /@polkadot/wasm-crypto/4.6.1_7agzzbeuhezrwkh2zmxh2lt2xi:
@@ -2003,6 +2319,23 @@ packages:
       '@polkadot/x-randomvalues': 10.1.11
     dev: false
 
+  /@polkadot/wasm-crypto/6.3.1_nz7hxxoej7rhwtqhu42recmbci:
+    resolution: {integrity: sha512-OO8h0qeVkqp4xYZaRVl4iuWOEtq282pNBHDKb6SOJuI2g59eWGcKh4EQU9Me2VP6qzojIqptrkrVt7KQXC68gA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
+      '@polkadot/wasm-bridge': 6.3.1_nz7hxxoej7rhwtqhu42recmbci
+      '@polkadot/wasm-crypto-asmjs': 6.3.1_@polkadot+util@10.1.13
+      '@polkadot/wasm-crypto-init': 6.3.1_nz7hxxoej7rhwtqhu42recmbci
+      '@polkadot/wasm-crypto-wasm': 6.3.1_@polkadot+util@10.1.13
+      '@polkadot/wasm-util': 6.3.1_@polkadot+util@10.1.13
+      '@polkadot/x-randomvalues': 10.1.13
+    dev: false
+
   /@polkadot/wasm-util/6.3.1_@polkadot+util@10.1.11:
     resolution: {integrity: sha512-12oAv5J7Yoc9m6jixrSaQCxpOkWOyzHx3DMC8qmLjRiwdBWxqLmImOVRVnFsbaxqSbhBIHRuJphVxWE+GZETDg==}
     engines: {node: '>=14.0.0'}
@@ -2023,6 +2356,16 @@ packages:
       '@polkadot/util': 10.1.12
     dev: false
 
+  /@polkadot/wasm-util/6.3.1_@polkadot+util@10.1.13:
+    resolution: {integrity: sha512-12oAv5J7Yoc9m6jixrSaQCxpOkWOyzHx3DMC8qmLjRiwdBWxqLmImOVRVnFsbaxqSbhBIHRuJphVxWE+GZETDg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@polkadot/util': '*'
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/util': 10.1.13
+    dev: false
+
   /@polkadot/x-bigint/10.1.11:
     resolution: {integrity: sha512-TC4KZ+ni/SJhcf/LIwD49C/kwvACu0nCchETNO+sAfJ7COXZwHDUJXVXmwN5PgkQxwsWsKKuJmzR/Fi1bgMWnQ==}
     engines: {node: '>=14.0.0'}
@@ -2037,6 +2380,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.1
       '@polkadot/x-global': 10.1.12
+    dev: false
+
+  /@polkadot/x-bigint/10.1.13:
+    resolution: {integrity: sha512-froRz2AC8pJ8TTmPUf7SRyWVO/U7GNjuVEtxumOv9IT6YOohV8N4zBdZVCc4Cr0dEAvGWAS11b0EgTyzBirq3A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/x-global': 10.1.13
     dev: false
 
   /@polkadot/x-bigint/10.1.7:
@@ -2061,6 +2412,16 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.1
       '@polkadot/x-global': 10.1.12
+      '@types/node-fetch': 2.6.2
+      node-fetch: 3.3.0
+    dev: false
+
+  /@polkadot/x-fetch/10.1.13:
+    resolution: {integrity: sha512-40WfW3rLMP1WfYrA0YlBnYWyNF5/lwSOpoQfnJ2vQHDvGRNmIJrQUAgxgjRjOVd+KKKE9e8s3W7TqjVhfoxrkQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/x-global': 10.1.13
       '@types/node-fetch': 2.6.2
       node-fetch: 3.3.0
     dev: false
@@ -2096,6 +2457,13 @@ packages:
 
   /@polkadot/x-global/10.1.12:
     resolution: {integrity: sha512-APFCIVoyaB9rhgcg2j5ayW0WVTSDO4yUriyrOPgX4A4ZJ6DFV+w30h9uWtfKzNzAV6dDs6pDNlB0K4Mpi5CmcA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+    dev: false
+
+  /@polkadot/x-global/10.1.13:
+    resolution: {integrity: sha512-9dQNjrXzdnjMFdpS1fcJRJveD8aQ2qyO5XWYnUmDjWVPmTY+olNuv7QOkfoJUgrFhqgeGEtUCmPZEWk8Tbwhqw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@babel/runtime': 7.20.1
@@ -2138,6 +2506,14 @@ packages:
       '@polkadot/x-global': 10.1.12
     dev: false
 
+  /@polkadot/x-randomvalues/10.1.13:
+    resolution: {integrity: sha512-yDXvOUiXIdysigOxNgTX0cJ5PF8qYXdn15PGyGFROKdBV5NW4Fn27xfFtNC0vpsbHl2G5KfE55uBdKwOkEvJVg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/x-global': 10.1.13
+    dev: false
+
   /@polkadot/x-randomvalues/6.11.1:
     resolution: {integrity: sha512-2MfUfGZSOkuPt7GF5OJkPDbl4yORI64SUuKM25EGrJ22o1UyoBnPOClm9eYujLMD6BfDZRM/7bQqqoLW+NuHVw==}
     engines: {node: '>=14.0.0'}
@@ -2176,6 +2552,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.1
       '@polkadot/x-global': 10.1.12
+    dev: false
+
+  /@polkadot/x-textdecoder/10.1.13:
+    resolution: {integrity: sha512-4i5u48ELGPN2D4Bq12q0ZZEx8uhd0M0sajpEwqGclOLYvMt/Uh3S6WA4rxHCwVd8z76NFiipw+HOBkdAaYzbqA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/x-global': 10.1.13
     dev: false
 
   /@polkadot/x-textdecoder/10.1.7:
@@ -2218,6 +2602,14 @@ packages:
       '@polkadot/x-global': 10.1.12
     dev: false
 
+  /@polkadot/x-textencoder/10.1.13:
+    resolution: {integrity: sha512-tkCgEydGChSXWhOuZYOOJ5DkdQq3Ev9zhs1cVdp1O72f/E7L6iv06WmfiFBeF+cX1/ymI3++IrOZqPI+t29gnA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/x-global': 10.1.13
+    dev: false
+
   /@polkadot/x-textencoder/10.1.7:
     resolution: {integrity: sha512-GzjaWZDbgzZ0IQT60xuZ7cZ0wnlNVYMqpfI9KvBc58X9dPI3TIMwzbXDVzZzpjY1SAqJGs4hJse9HMWZazfhew==}
     engines: {node: '>=14.0.0'}
@@ -2248,6 +2640,18 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.1
       '@polkadot/x-global': 10.1.12
+      '@types/websocket': 1.0.5
+      websocket: 1.0.34
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@polkadot/x-ws/10.1.13:
+    resolution: {integrity: sha512-hs9v/i0bAcmazZI0R8kgao3/NzBxTMFzUVEbH11yDzL3RCWKYPIbeK4VwI31VUOzIIsjhNgCegSueJMkLn4F5Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@polkadot/x-global': 10.1.13
       '@types/websocket': 1.0.5
       websocket: 1.0.34
     transitivePeerDependencies:
@@ -2403,7 +2807,7 @@ packages:
   /@subsocial/definitions/0.7.8-dev.0:
     resolution: {integrity: sha512-gWzNm9wLixvWdYhdHVgS2xEznzgK/WNt0c2ghF1d9MJNGj38BtYZIeyoTnXL1Rq31pOo8I2iVvYDh5/AHcm3mA==}
     dependencies:
-      '@polkadot/api': 9.8.1
+      '@polkadot/api': 9.9.1
       lodash.camelcase: 4.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -2430,6 +2834,17 @@ packages:
     dependencies:
       '@substrate/connect-extension-protocol': 1.0.1
       '@substrate/smoldot-light': 0.7.5
+      eventemitter3: 4.0.7
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@substrate/connect/0.7.17:
+    resolution: {integrity: sha512-s0XBmGpUCFWZFa+TS0TEvOKtWjJP2uT4xKmvzApH8INB5xbz79wqWFX6WWh3AlK/X1P0Smt+RVEH7HQiLJAYAw==}
+    dependencies:
+      '@substrate/connect-extension-protocol': 1.0.1
+      '@substrate/smoldot-light': 0.7.7
       eventemitter3: 4.0.7
     transitivePeerDependencies:
       - bufferutil
@@ -2474,20 +2889,46 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@substrate/smoldot-light/0.7.7:
+    resolution: {integrity: sha512-ksxeAed6dIUtYSl0f8ehgWQjwXnpDGTIJt+WVRIGt3OObZkA96ZdBWx0xP7GrXZtj37u4n/Y1z7TyTm4bwQvrw==}
+    dependencies:
+      pako: 2.1.0
+      ws: 8.11.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /@substrate/ss58-registry/1.34.0:
     resolution: {integrity: sha512-8Df5usnWvjnw/WRAmKOqHXRPPRfiCd1kIN8ttH4YmBrRTERjVInsdu0xvLdbyUYKyvgK6zKhHWQfYohXqllHhg==}
     dev: false
 
+  /@tsconfig/node10/1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: true
+
+  /@tsconfig/node12/1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14/1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16/1.0.3:
+    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+    dev: true
+
   /@types/bn.js/4.11.6:
     resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
     dependencies:
-      '@types/node': 18.7.14
+      '@types/node': 18.11.9
     dev: false
 
   /@types/bn.js/5.1.1:
     resolution: {integrity: sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==}
     dependencies:
-      '@types/node': 18.7.14
+      '@types/node': 18.11.9
     dev: false
 
   /@types/chai-subset/1.3.3:
@@ -2523,12 +2964,12 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 18.7.14
+      '@types/node': 18.11.9
       form-data: 3.0.1
     dev: false
 
-  /@types/node/18.7.14:
-    resolution: {integrity: sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==}
+  /@types/node/18.11.9:
+    resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -2538,6 +2979,10 @@ packages:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
+  /@types/semver/7.3.13:
+    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+    dev: true
+
   /@types/uuid/8.3.4:
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
     dev: false
@@ -2545,11 +2990,11 @@ packages:
   /@types/websocket/1.0.5:
     resolution: {integrity: sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==}
     dependencies:
-      '@types/node': 18.7.14
+      '@types/node': 18.11.9
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.36.1_ptjtm5ueew7d66dpdptn6han3m:
-    resolution: {integrity: sha512-iC40UK8q1tMepSDwiLbTbMXKDxzNy+4TfPWgIL661Ym0sD42vRcQU93IsZIrmi+x292DBr60UI/gSwfdVYexCA==}
+  /@typescript-eslint/eslint-plugin/5.43.0_nqj4bdx4ekws7aecttskpih4py:
+    resolution: {integrity: sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -2559,24 +3004,24 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1_rmayb2veg2btbq6mbmnyivgasy
-      '@typescript-eslint/scope-manager': 5.36.1
-      '@typescript-eslint/type-utils': 5.36.1_rmayb2veg2btbq6mbmnyivgasy
-      '@typescript-eslint/utils': 5.36.1_rmayb2veg2btbq6mbmnyivgasy
+      '@typescript-eslint/parser': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/scope-manager': 5.43.0
+      '@typescript-eslint/type-utils': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/utils': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
       debug: 4.3.4
-      eslint: 8.27.0
-      functional-red-black-tree: 1.0.1
+      eslint: 8.28.0
       ignore: 5.2.0
+      natural-compare-lite: 1.4.0
       regexpp: 3.2.0
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.36.1_rmayb2veg2btbq6mbmnyivgasy:
-    resolution: {integrity: sha512-/IsgNGOkBi7CuDfUbwt1eOqUXF9WGVBW9dwEe1pi+L32XrTsZIgmDFIi2RxjzsvB/8i+MIf5JIoTEH8LOZ368A==}
+  /@typescript-eslint/parser/5.43.0_hsf322ms6xhhd4b5ne6lb74y4a:
+    resolution: {integrity: sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2585,26 +3030,26 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.36.1
-      '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.43.0
+      '@typescript-eslint/types': 5.43.0
+      '@typescript-eslint/typescript-estree': 5.43.0_typescript@4.9.3
       debug: 4.3.4
-      eslint: 8.27.0
-      typescript: 4.8.4
+      eslint: 8.28.0
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/5.36.1:
-    resolution: {integrity: sha512-pGC2SH3/tXdu9IH3ItoqciD3f3RRGCh7hb9zPdN2Drsr341zgd6VbhP5OHQO/reUqihNltfPpMpTNihFMarP2w==}
+  /@typescript-eslint/scope-manager/5.43.0:
+    resolution: {integrity: sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/visitor-keys': 5.36.1
+      '@typescript-eslint/types': 5.43.0
+      '@typescript-eslint/visitor-keys': 5.43.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.36.1_rmayb2veg2btbq6mbmnyivgasy:
-    resolution: {integrity: sha512-xfZhfmoQT6m3lmlqDvDzv9TiCYdw22cdj06xY0obSznBsT///GK5IEZQdGliXpAOaRL34o8phEvXzEo/VJx13Q==}
+  /@typescript-eslint/type-utils/5.43.0_hsf322ms6xhhd4b5ne6lb74y4a:
+    resolution: {integrity: sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -2613,23 +3058,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.8.4
-      '@typescript-eslint/utils': 5.36.1_rmayb2veg2btbq6mbmnyivgasy
+      '@typescript-eslint/typescript-estree': 5.43.0_typescript@4.9.3
+      '@typescript-eslint/utils': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
       debug: 4.3.4
-      eslint: 8.27.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      eslint: 8.28.0
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types/5.36.1:
-    resolution: {integrity: sha512-jd93ShpsIk1KgBTx9E+hCSEuLCUFwi9V/urhjOWnOaksGZFbTOxAT47OH2d4NLJnLhkVD+wDbB48BuaycZPLBg==}
+  /@typescript-eslint/types/5.43.0:
+    resolution: {integrity: sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.36.1_typescript@4.8.4:
-    resolution: {integrity: sha512-ih7V52zvHdiX6WcPjsOdmADhYMDN15SylWRZrT2OMy80wzKbc79n8wFW0xpWpU0x3VpBz/oDgTm2xwDAnFTl+g==}
+  /@typescript-eslint/typescript-estree/5.43.0_typescript@4.9.3:
+    resolution: {integrity: sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -2637,41 +3082,43 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/visitor-keys': 5.36.1
+      '@typescript-eslint/types': 5.43.0
+      '@typescript-eslint/visitor-keys': 5.43.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.36.1_rmayb2veg2btbq6mbmnyivgasy:
-    resolution: {integrity: sha512-lNj4FtTiXm5c+u0pUehozaUWhh7UYKnwryku0nxJlYUEWetyG92uw2pr+2Iy4M/u0ONMKzfrx7AsGBTCzORmIg==}
+  /@typescript-eslint/utils/5.43.0_hsf322ms6xhhd4b5ne6lb74y4a:
+    resolution: {integrity: sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 5.36.1
-      '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.8.4
-      eslint: 8.27.0
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.43.0
+      '@typescript-eslint/types': 5.43.0
+      '@typescript-eslint/typescript-estree': 5.43.0_typescript@4.9.3
+      eslint: 8.28.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.27.0
+      eslint-utils: 3.0.0_eslint@8.28.0
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.36.1:
-    resolution: {integrity: sha512-ojB9aRyRFzVMN3b5joSYni6FAS10BBSCAfKJhjJAV08t/a95aM6tAhz+O1jF+EtgxktuSO3wJysp2R+Def/IWQ==}
+  /@typescript-eslint/visitor-keys/5.43.0:
+    resolution: {integrity: sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.36.1
+      '@typescript-eslint/types': 5.43.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -2707,11 +3154,11 @@ packages:
       '@polkadot/types': 9.8.1
     dev: false
 
-  /@vitest/coverage-c8/0.25.1:
-    resolution: {integrity: sha512-gpl5QNaNeIN0mfRiosCqBFoZcizb5GA458TDnOQXkGDc4kklazxn70u9evGfV62wiiAUfGGebgRhxlBkAa6m6g==}
+  /@vitest/coverage-c8/0.25.2:
+    resolution: {integrity: sha512-qKsiUJh3bjbB5Q229CbxEWCqiDBwvIrcZ9OOuQdMEC0pce3/LlTUK3+K3hd7WqAYEbbiqXfC5MVMKHZkV82PgA==}
     dependencies:
       c8: 7.12.0
-      vitest: 0.25.1
+      vitest: 0.25.2
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -2741,12 +3188,12 @@ packages:
       through: 2.3.8
     dev: true
 
-  /acorn-jsx/5.3.2_acorn@8.8.0:
+  /acorn-jsx/5.3.2_acorn@8.8.1:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.0
+      acorn: 8.8.1
     dev: true
 
   /acorn-walk/8.2.0:
@@ -2756,6 +3203,12 @@ packages:
 
   /acorn/8.8.0:
     resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn/8.8.1:
+    resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -2794,6 +3247,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: true
+
+  /arg/4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
     dev: true
 
   /argparse/2.0.1:
@@ -2939,7 +3396,7 @@ packages:
   /builtins/5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.3.7
+      semver: 7.3.8
     dev: true
 
   /c8/7.12.0:
@@ -3029,8 +3486,9 @@ packages:
     resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
     dev: true
 
-  /ci-info/3.3.2:
-    resolution: {integrity: sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==}
+  /ci-info/3.6.1:
+    resolution: {integrity: sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==}
+    engines: {node: '>=8'}
     dev: true
 
   /cipher-base/1.0.4:
@@ -3297,6 +3755,10 @@ packages:
       sha.js: 2.4.11
     dev: false
 
+  /create-require/1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
   /cross-spawn/7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -3411,8 +3873,8 @@ packages:
       object-keys: 1.1.1
     dev: true
 
-  /defu/6.1.0:
-    resolution: {integrity: sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==}
+  /defu/6.1.1:
+    resolution: {integrity: sha512-aA964RUCsBt0FGoNIlA3uFgo2hO+WWC0fiC6DBps/0SFzkKcYoM/3CzVLIa5xSsrFjdioMdYgAIbwo80qp2MoA==}
     dev: true
 
   /delayed-stream/1.0.0:
@@ -3428,6 +3890,11 @@ packages:
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /diff/4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
     dev: true
 
   /dir-glob/3.0.1:
@@ -3584,8 +4051,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-android-64/0.15.13:
-    resolution: {integrity: sha512-yRorukXBlokwTip+Sy4MYskLhJsO0Kn0/Fj43s1krVblfwP+hMD37a4Wmg139GEsMLl+vh8WXp2mq/cTA9J97g==}
+  /esbuild-android-64/0.15.14:
+    resolution: {integrity: sha512-HuilVIb4rk9abT4U6bcFdU35UHOzcWVGLSjEmC58OVr96q5UiRqzDtWjPlCMugjhgUGKEs8Zf4ueIvYbOStbIg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -3602,8 +4069,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-android-arm64/0.15.13:
-    resolution: {integrity: sha512-TKzyymLD6PiVeyYa4c5wdPw87BeAiTXNtK6amWUcXZxkV51gOk5u5qzmDaYSwiWeecSNHamFsaFjLoi32QR5/w==}
+  /esbuild-android-arm64/0.15.14:
+    resolution: {integrity: sha512-/QnxRVxsR2Vtf3XottAHj7hENAMW2wCs6S+OZcAbc/8nlhbAL/bCQRCVD78VtI5mdwqWkVi3wMqM94kScQCgqg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -3620,8 +4087,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-darwin-64/0.15.13:
-    resolution: {integrity: sha512-WAx7c2DaOS6CrRcoYCgXgkXDliLnFv3pQLV6GeW1YcGEZq2Gnl8s9Pg7ahValZkpOa0iE/ojRVQ87sbUhF1Cbg==}
+  /esbuild-darwin-64/0.15.14:
+    resolution: {integrity: sha512-ToNuf1uifu8hhwWvoZJGCdLIX/1zpo8cOGnT0XAhDQXiKOKYaotVNx7pOVB1f+wHoWwTLInrOmh3EmA7Fd+8Vg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -3638,8 +4105,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-darwin-arm64/0.15.13:
-    resolution: {integrity: sha512-U6jFsPfSSxC3V1CLiQqwvDuj3GGrtQNB3P3nNC3+q99EKf94UGpsG9l4CQ83zBs1NHrk1rtCSYT0+KfK5LsD8A==}
+  /esbuild-darwin-arm64/0.15.14:
+    resolution: {integrity: sha512-KgGP+y77GszfYJgceO0Wi/PiRtYo5y2Xo9rhBUpxTPaBgWDJ14gqYN0+NMbu+qC2fykxXaipHxN4Scaj9tUS1A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -3656,8 +4123,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-freebsd-64/0.15.13:
-    resolution: {integrity: sha512-whItJgDiOXaDG/idy75qqevIpZjnReZkMGCgQaBWZuKHoElDJC1rh7MpoUgupMcdfOd+PgdEwNQW9DAE6i8wyA==}
+  /esbuild-freebsd-64/0.15.14:
+    resolution: {integrity: sha512-xr0E2n5lyWw3uFSwwUXHc0EcaBDtsal/iIfLioflHdhAe10KSctV978Te7YsfnsMKzcoGeS366+tqbCXdqDHQA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -3674,8 +4141,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-freebsd-arm64/0.15.13:
-    resolution: {integrity: sha512-6pCSWt8mLUbPtygv7cufV0sZLeylaMwS5Fznj6Rsx9G2AJJsAjQ9ifA+0rQEIg7DwJmi9it+WjzNTEAzzdoM3Q==}
+  /esbuild-freebsd-arm64/0.15.14:
+    resolution: {integrity: sha512-8XH96sOQ4b1LhMlO10eEWOjEngmZ2oyw3pW4o8kvBcpF6pULr56eeYVP5radtgw54g3T8nKHDHYEI5AItvskZg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -3692,8 +4159,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-32/0.15.13:
-    resolution: {integrity: sha512-VbZdWOEdrJiYApm2kkxoTOgsoCO1krBZ3quHdYk3g3ivWaMwNIVPIfEE0f0XQQ0u5pJtBsnk2/7OPiCFIPOe/w==}
+  /esbuild-linux-32/0.15.14:
+    resolution: {integrity: sha512-6ssnvwaTAi8AzKN8By2V0nS+WF5jTP7SfuK6sStGnDP7MCJo/4zHgM9oE1eQTS2jPmo3D673rckuCzRlig+HMA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -3710,8 +4177,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-64/0.15.13:
-    resolution: {integrity: sha512-rXmnArVNio6yANSqDQlIO4WiP+Cv7+9EuAHNnag7rByAqFVuRusLbGi2697A5dFPNXoO//IiogVwi3AdcfPC6A==}
+  /esbuild-linux-64/0.15.14:
+    resolution: {integrity: sha512-ONySx3U0wAJOJuxGUlXBWxVKFVpWv88JEv0NZ6NlHknmDd1yCbf4AEdClSgLrqKQDXYywmw4gYDvdLsS6z0hcw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -3728,8 +4195,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-arm/0.15.13:
-    resolution: {integrity: sha512-Ac6LpfmJO8WhCMQmO253xX2IU2B3wPDbl4IvR0hnqcPrdfCaUa2j/lLMGTjmQ4W5JsJIdHEdW12dG8lFS0MbxQ==}
+  /esbuild-linux-arm/0.15.14:
+    resolution: {integrity: sha512-D2LImAIV3QzL7lHURyCHBkycVFbKwkDb1XEUWan+2fb4qfW7qAeUtul7ZIcIwFKZgPcl+6gKZmvLgPSj26RQ2Q==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -3746,8 +4213,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-arm64/0.15.13:
-    resolution: {integrity: sha512-alEMGU4Z+d17U7KQQw2IV8tQycO6T+rOrgW8OS22Ua25x6kHxoG6Ngry6Aq6uranC+pNWNMB6aHFPh7aTQdORQ==}
+  /esbuild-linux-arm64/0.15.14:
+    resolution: {integrity: sha512-kle2Ov6a1e5AjlHlMQl1e+c4myGTeggrRzArQFmWp6O6JoqqB9hT+B28EW4tjFWgV/NxUq46pWYpgaWXsXRPAg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -3764,8 +4231,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-mips64le/0.15.13:
-    resolution: {integrity: sha512-47PgmyYEu+yN5rD/MbwS6DxP2FSGPo4Uxg5LwIdxTiyGC2XKwHhHyW7YYEDlSuXLQXEdTO7mYe8zQ74czP7W8A==}
+  /esbuild-linux-mips64le/0.15.14:
+    resolution: {integrity: sha512-FVdMYIzOLXUq+OE7XYKesuEAqZhmAIV6qOoYahvUp93oXy0MOVTP370ECbPfGXXUdlvc0TNgkJa3YhEwyZ6MRA==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -3782,8 +4249,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-ppc64le/0.15.13:
-    resolution: {integrity: sha512-z6n28h2+PC1Ayle9DjKoBRcx/4cxHoOa2e689e2aDJSaKug3jXcQw7mM+GLg+9ydYoNzj8QxNL8ihOv/OnezhA==}
+  /esbuild-linux-ppc64le/0.15.14:
+    resolution: {integrity: sha512-2NzH+iuzMDA+jjtPjuIz/OhRDf8tzbQ1tRZJI//aT25o1HKc0reMMXxKIYq/8nSHXiJSnYV4ODzTiv45s+h73w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -3800,8 +4267,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-riscv64/0.15.13:
-    resolution: {integrity: sha512-+Lu4zuuXuQhgLUGyZloWCqTslcCAjMZH1k3Xc9MSEJEpEFdpsSU0sRDXAnk18FKOfEjhu4YMGaykx9xjtpA6ow==}
+  /esbuild-linux-riscv64/0.15.14:
+    resolution: {integrity: sha512-VqxvutZNlQxmUNS7Ac+aczttLEoHBJ9e3OYGqnULrfipRvG97qLrAv9EUY9iSrRKBqeEbSvS9bSfstZqwz0T4Q==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -3818,8 +4285,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-s390x/0.15.13:
-    resolution: {integrity: sha512-BMeXRljruf7J0TMxD5CIXS65y7puiZkAh+s4XFV9qy16SxOuMhxhVIXYLnbdfLrsYGFzx7U9mcdpFWkkvy/Uag==}
+  /esbuild-linux-s390x/0.15.14:
+    resolution: {integrity: sha512-+KVHEUshX5n6VP6Vp/AKv9fZIl5kr2ph8EUFmQUJnDpHwcfTSn2AQgYYm0HTBR2Mr4d0Wlr0FxF/Cs5pbFgiOw==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -3836,8 +4303,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-netbsd-64/0.15.13:
-    resolution: {integrity: sha512-EHj9QZOTel581JPj7UO3xYbltFTYnHy+SIqJVq6yd3KkCrsHRbapiPb0Lx3EOOtybBEE9EyqbmfW1NlSDsSzvQ==}
+  /esbuild-netbsd-64/0.15.14:
+    resolution: {integrity: sha512-6D/dr17piEgevIm1xJfZP2SjB9Z+g8ERhNnBdlZPBWZl+KSPUKLGF13AbvC+nzGh8IxOH2TyTIdRMvKMP0nEzQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -3854,8 +4321,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-openbsd-64/0.15.13:
-    resolution: {integrity: sha512-nkuDlIjF/sfUhfx8SKq0+U+Fgx5K9JcPq1mUodnxI0x4kBdCv46rOGWbuJ6eof2n3wdoCLccOoJAbg9ba/bT2w==}
+  /esbuild-openbsd-64/0.15.14:
+    resolution: {integrity: sha512-rREQBIlMibBetgr2E9Lywt2Qxv2ZdpmYahR4IUlAQ1Efv/A5gYdO0/VIN3iowDbCNTLxp0bb57Vf0LFcffD6kA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -3872,8 +4339,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-sunos-64/0.15.13:
-    resolution: {integrity: sha512-jVeu2GfxZQ++6lRdY43CS0Tm/r4WuQQ0Pdsrxbw+aOrHQPHV0+LNOLnvbN28M7BSUGnJnHkHm2HozGgNGyeIRw==}
+  /esbuild-sunos-64/0.15.14:
+    resolution: {integrity: sha512-DNVjSp/BY4IfwtdUAvWGIDaIjJXY5KI4uD82+15v6k/w7px9dnaDaJJ2R6Mu+KCgr5oklmFc0KjBjh311Gxl9Q==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -3890,8 +4357,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-32/0.15.13:
-    resolution: {integrity: sha512-XoF2iBf0wnqo16SDq+aDGi/+QbaLFpkiRarPVssMh9KYbFNCqPLlGAWwDvxEVz+ywX6Si37J2AKm+AXq1kC0JA==}
+  /esbuild-windows-32/0.15.14:
+    resolution: {integrity: sha512-pHBWrcA+/oLgvViuG9FO3kNPO635gkoVrRQwe6ZY1S0jdET07xe2toUvQoJQ8KT3/OkxqUasIty5hpuKFLD+eg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -3908,8 +4375,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-64/0.15.13:
-    resolution: {integrity: sha512-Et6htEfGycjDrtqb2ng6nT+baesZPYQIW+HUEHK4D1ncggNrDNk3yoboYQ5KtiVrw/JaDMNttz8rrPubV/fvPQ==}
+  /esbuild-windows-64/0.15.14:
+    resolution: {integrity: sha512-CszIGQVk/P8FOS5UgAH4hKc9zOaFo69fe+k1rqgBHx3CSK3Opyk5lwYriIamaWOVjBt7IwEP6NALz+tkVWdFog==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -3926,8 +4393,8 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-arm64/0.15.13:
-    resolution: {integrity: sha512-3bv7tqntThQC9SWLRouMDmZnlOukBhOCTlkzNqzGCmrkCJI7io5LLjwJBOVY6kOUlIvdxbooNZwjtBvj+7uuVg==}
+  /esbuild-windows-arm64/0.15.14:
+    resolution: {integrity: sha512-KW9W4psdZceaS9A7Jsgl4WialOznSURvqX/oHZk3gOP7KbjtHLSsnmSvNdzagGJfxbAe30UVGXRe8q8nDsOSQw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -3964,34 +4431,34 @@ packages:
       esbuild-windows-arm64: 0.14.54
     dev: true
 
-  /esbuild/0.15.13:
-    resolution: {integrity: sha512-Cu3SC84oyzzhrK/YyN4iEVy2jZu5t2fz66HEOShHURcjSkOSAVL8C/gfUT+lDJxkVHpg8GZ10DD0rMHRPqMFaQ==}
+  /esbuild/0.15.14:
+    resolution: {integrity: sha512-pJN8j42fvWLFWwSMG4luuupl2Me7mxciUOsMegKvwCmhEbJ2covUdFnihxm0FMIBV+cbwbtMoHgMCCI+pj1btQ==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.15.13
-      '@esbuild/linux-loong64': 0.15.13
-      esbuild-android-64: 0.15.13
-      esbuild-android-arm64: 0.15.13
-      esbuild-darwin-64: 0.15.13
-      esbuild-darwin-arm64: 0.15.13
-      esbuild-freebsd-64: 0.15.13
-      esbuild-freebsd-arm64: 0.15.13
-      esbuild-linux-32: 0.15.13
-      esbuild-linux-64: 0.15.13
-      esbuild-linux-arm: 0.15.13
-      esbuild-linux-arm64: 0.15.13
-      esbuild-linux-mips64le: 0.15.13
-      esbuild-linux-ppc64le: 0.15.13
-      esbuild-linux-riscv64: 0.15.13
-      esbuild-linux-s390x: 0.15.13
-      esbuild-netbsd-64: 0.15.13
-      esbuild-openbsd-64: 0.15.13
-      esbuild-sunos-64: 0.15.13
-      esbuild-windows-32: 0.15.13
-      esbuild-windows-64: 0.15.13
-      esbuild-windows-arm64: 0.15.13
+      '@esbuild/android-arm': 0.15.14
+      '@esbuild/linux-loong64': 0.15.14
+      esbuild-android-64: 0.15.14
+      esbuild-android-arm64: 0.15.14
+      esbuild-darwin-64: 0.15.14
+      esbuild-darwin-arm64: 0.15.14
+      esbuild-freebsd-64: 0.15.14
+      esbuild-freebsd-arm64: 0.15.14
+      esbuild-linux-32: 0.15.14
+      esbuild-linux-64: 0.15.14
+      esbuild-linux-arm: 0.15.14
+      esbuild-linux-arm64: 0.15.14
+      esbuild-linux-mips64le: 0.15.14
+      esbuild-linux-ppc64le: 0.15.14
+      esbuild-linux-riscv64: 0.15.14
+      esbuild-linux-s390x: 0.15.14
+      esbuild-netbsd-64: 0.15.14
+      esbuild-openbsd-64: 0.15.14
+      esbuild-sunos-64: 0.15.14
+      esbuild-windows-32: 0.15.14
+      esbuild-windows-64: 0.15.14
+      esbuild-windows-arm64: 0.15.14
     dev: true
 
   /escalade/3.1.1:
@@ -4009,7 +4476,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-standard/17.0.0_yqvjeq2xzul43p26zlvfoiu3rm:
+  /eslint-config-standard/17.0.0_5dakk4wnrkkieagghiqvu5yn4y:
     resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
     peerDependencies:
       eslint: ^8.0.1
@@ -4017,10 +4484,10 @@ packages:
       eslint-plugin-n: ^15.0.0
       eslint-plugin-promise: ^6.0.0
     dependencies:
-      eslint: 8.27.0
-      eslint-plugin-import: 2.26.0_ankxupw42u6sowqa4gjcxemuni
-      eslint-plugin-n: 15.2.5_eslint@8.27.0
-      eslint-plugin-promise: 6.0.1_eslint@8.27.0
+      eslint: 8.28.0
+      eslint-plugin-import: 2.26.0_d5vn4nsvkp5ugznurcfxmdkaeu
+      eslint-plugin-n: 15.5.1_eslint@8.28.0
+      eslint-plugin-promise: 6.1.1_eslint@8.28.0
     dev: true
 
   /eslint-import-resolver-node/0.3.6:
@@ -4032,27 +4499,27 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/3.5.0_dcpv4nbdr5ks2h5677xdltrk6e:
-    resolution: {integrity: sha512-DEfpfuk+O/T5e9HBZOxocmwMuUGkvQQd5WRiMJF9kKNT9amByqOyGlWoAZAQiv0SZSy4GMtG1clmnvQA/RzA0A==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+  /eslint-import-resolver-typescript/3.5.2_ktrec6dplf4now6nlbc6d67jee:
+    resolution: {integrity: sha512-zX4ebnnyXiykjhcBvKIf5TNvt8K7yX6bllTRZ14MiurKPjDpCAZujlszTdB8pcNXhZcOf+god4s9SjQa5GnytQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.10.0
-      eslint: 8.27.0
-      eslint-plugin-import: 2.26.0_ankxupw42u6sowqa4gjcxemuni
+      eslint: 8.28.0
+      eslint-plugin-import: 2.26.0_d5vn4nsvkp5ugznurcfxmdkaeu
       get-tsconfig: 4.2.0
       globby: 13.1.2
-      is-core-module: 2.10.0
+      is-core-module: 2.11.0
       is-glob: 4.0.3
       synckit: 0.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.4_tp5imgidbcekhicqfwzdvt4zwa:
+  /eslint-module-utils/2.7.4_hkyvkcuamndkjh6xd3yrie643u:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4073,38 +4540,38 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1_rmayb2veg2btbq6mbmnyivgasy
+      '@typescript-eslint/parser': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
       debug: 3.2.7
-      eslint: 8.27.0
+      eslint: 8.28.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.0_dcpv4nbdr5ks2h5677xdltrk6e
+      eslint-import-resolver-typescript: 3.5.2_ktrec6dplf4now6nlbc6d67jee
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-es/3.0.1_eslint@8.27.0:
+  /eslint-plugin-es/3.0.1_eslint@8.28.0:
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.27.0
+      eslint: 8.28.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-es/4.1.0_eslint@8.27.0:
+  /eslint-plugin-es/4.1.0_eslint@8.28.0:
     resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.27.0
+      eslint: 8.28.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-import/2.26.0_ankxupw42u6sowqa4gjcxemuni:
+  /eslint-plugin-import/2.26.0_d5vn4nsvkp5ugznurcfxmdkaeu:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4114,16 +4581,16 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1_rmayb2veg2btbq6mbmnyivgasy
+      '@typescript-eslint/parser': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.27.0
+      eslint: 8.28.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_tp5imgidbcekhicqfwzdvt4zwa
+      eslint-module-utils: 2.7.4_hkyvkcuamndkjh6xd3yrie643u
       has: 1.0.3
-      is-core-module: 2.10.0
+      is-core-module: 2.11.0
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.values: 1.1.5
@@ -4135,31 +4602,31 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-n/15.2.5_eslint@8.27.0:
-    resolution: {integrity: sha512-8+BYsqiyZfpu6NXmdLOXVUfk8IocpCjpd8nMRRH0A9ulrcemhb2VI9RSJMEy5udx++A/YcVPD11zT8hpFq368g==}
+  /eslint-plugin-n/15.5.1_eslint@8.28.0:
+    resolution: {integrity: sha512-kAd+xhZm7brHoFLzKLB7/FGRFJNg/srmv67mqb7tto22rpr4wv/LV6RuXzAfv3jbab7+k1wi42PsIhGviywaaw==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
       builtins: 5.0.1
-      eslint: 8.27.0
-      eslint-plugin-es: 4.1.0_eslint@8.27.0
-      eslint-utils: 3.0.0_eslint@8.27.0
+      eslint: 8.28.0
+      eslint-plugin-es: 4.1.0_eslint@8.28.0
+      eslint-utils: 3.0.0_eslint@8.28.0
       ignore: 5.2.0
-      is-core-module: 2.10.0
+      is-core-module: 2.11.0
       minimatch: 3.1.2
       resolve: 1.22.1
-      semver: 7.3.7
+      semver: 7.3.8
     dev: true
 
-  /eslint-plugin-node/11.1.0_eslint@8.27.0:
+  /eslint-plugin-node/11.1.0_eslint@8.28.0:
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=5.16.0'
     dependencies:
-      eslint: 8.27.0
-      eslint-plugin-es: 3.0.1_eslint@8.27.0
+      eslint: 8.28.0
+      eslint-plugin-es: 3.0.1_eslint@8.28.0
       eslint-utils: 2.1.0
       ignore: 5.2.0
       minimatch: 3.1.2
@@ -4167,26 +4634,26 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-promise/6.0.1_eslint@8.27.0:
-    resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
+  /eslint-plugin-promise/6.1.1_eslint@8.28.0:
+    resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.27.0
+      eslint: 8.28.0
     dev: true
 
-  /eslint-plugin-unicorn/43.0.2_eslint@8.27.0:
-    resolution: {integrity: sha512-DtqZ5mf/GMlfWoz1abIjq5jZfaFuHzGBZYIeuJfEoKKGWRHr2JiJR+ea+BF7Wx2N1PPRoT/2fwgiK1NnmNE3Hg==}
+  /eslint-plugin-unicorn/44.0.2_eslint@8.28.0:
+    resolution: {integrity: sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==}
     engines: {node: '>=14.18'}
     peerDependencies:
-      eslint: '>=8.18.0'
+      eslint: '>=8.23.1'
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
-      ci-info: 3.3.2
+      ci-info: 3.6.1
       clean-regexp: 1.0.0
-      eslint: 8.27.0
-      eslint-utils: 3.0.0_eslint@8.27.0
+      eslint: 8.28.0
+      eslint-utils: 3.0.0_eslint@8.28.0
       esquery: 1.4.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.0
@@ -4195,23 +4662,23 @@ packages:
       read-pkg-up: 7.0.1
       regexp-tree: 0.1.24
       safe-regex: 2.1.1
-      semver: 7.3.7
+      semver: 7.3.8
       strip-indent: 3.0.0
     dev: true
 
-  /eslint-plugin-vue/9.4.0_eslint@8.27.0:
-    resolution: {integrity: sha512-Nzz2QIJ8FG+rtJaqT/7/ru5ie2XgT9KCudkbN0y3uFYhQ41nuHEaboLAiqwMcK006hZPQv/rVMRhUIwEGhIvfQ==}
+  /eslint-plugin-vue/9.7.0_eslint@8.28.0:
+    resolution: {integrity: sha512-DrOO3WZCZEwcLsnd3ohFwqCoipGRSTKTBTnLwdhqAbYZtzWl0o7D+D8ZhlmiZvABKTEl8AFsqH1GHGdybyoQmw==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.27.0
-      eslint-utils: 3.0.0_eslint@8.27.0
+      eslint: 8.28.0
+      eslint-utils: 3.0.0_eslint@8.28.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.0.10
-      semver: 7.3.7
-      vue-eslint-parser: 9.0.3_eslint@8.27.0
+      semver: 7.3.8
+      vue-eslint-parser: 9.0.3_eslint@8.28.0
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -4240,13 +4707,13 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@8.27.0:
+  /eslint-utils/3.0.0_eslint@8.28.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.27.0
+      eslint: 8.28.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -4265,8 +4732,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint/8.27.0:
-    resolution: {integrity: sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==}
+  /eslint/8.28.0:
+    resolution: {integrity: sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
@@ -4281,7 +4748,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.27.0
+      eslint-utils: 3.0.0_eslint@8.28.0
       eslint-visitor-keys: 3.3.0
       espree: 9.4.0
       esquery: 1.4.0
@@ -4317,8 +4784,8 @@ packages:
     resolution: {integrity: sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.0
-      acorn-jsx: 5.3.2_acorn@8.8.0
+      acorn: 8.8.1
+      acorn-jsx: 5.3.2_acorn@8.8.1
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -4564,10 +5031,6 @@ packages:
       define-properties: 1.1.4
       es-abstract: 1.20.2
       functions-have-names: 1.2.3
-    dev: true
-
-  /functional-red-black-tree/1.0.1:
-    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
     dev: true
 
   /functions-have-names/1.2.3:
@@ -4822,8 +5285,8 @@ packages:
       minimalistic-crypto-utils: 1.0.1
     dev: false
 
-  /hookable/5.4.1:
-    resolution: {integrity: sha512-i808BglQ1OuSIcgPSZoWsDapCMLXKe5wLS6XZvIXpaBWdWLUZARM8vOLayu6cXewj5TSbaZaMzKnq+pRnfscEQ==}
+  /hookable/5.4.2:
+    resolution: {integrity: sha512-6rOvaUiNKy9lET1X0ECnyZ5O5kSV0PJbtA5yZUgdEF7fGJEVwSLSislltyt7nFwVVALYHQJtfGeAR2Y0A0uJkg==}
     dev: true
 
   /hosted-git-info/2.8.9:
@@ -4926,8 +5389,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /is-core-module/2.10.0:
-    resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
+  /is-core-module/2.11.0:
+    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
     dev: true
@@ -5268,6 +5731,10 @@ packages:
       semver: 6.3.0
     dev: true
 
+  /make-error/1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
   /map-obj/1.0.1:
     resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
     engines: {node: '>=0.10.0'}
@@ -5373,32 +5840,35 @@ packages:
     hasBin: true
     dev: true
 
-  /mkdist/0.3.13_typescript@4.8.4:
-    resolution: {integrity: sha512-+eCPpkr8l2X630y5PIlkts2tzYEsb+aGIgXdrQv9ZGtWE2bLlD6kVIFfI6FJwFpjjw4dPPyorxQc6Uhm/oXlvg==}
+  /mkdist/1.0.0_typescript@4.9.3:
+    resolution: {integrity: sha512-aJke+yvXwwcrOh+3KfAdDgDA+MPe7c+R8hQ7IPfp0gqL1/WPZZUS9rwS6CNjdwDJmHm6DTMA9KwX1FNjZG3I1Q==}
     hasBin: true
     peerDependencies:
-      typescript: '>=4.7.4'
+      sass: ^1.56.1
+      typescript: '>=4.8.4'
     peerDependenciesMeta:
+      sass:
+        optional: true
       typescript:
         optional: true
     dependencies:
-      defu: 6.1.0
-      esbuild: 0.14.54
+      defu: 6.1.1
+      esbuild: 0.15.14
       fs-extra: 10.1.0
-      globby: 11.1.0
+      globby: 13.1.2
       jiti: 1.16.0
       mri: 1.2.0
-      pathe: 0.2.0
-      typescript: 4.8.4
+      pathe: 1.0.0
+      typescript: 4.9.3
     dev: true
 
-  /mlly/0.5.16:
-    resolution: {integrity: sha512-LaJ8yuh4v0zEmge/g3c7jjFlhoCPfQn6RCjXgm9A0Qiuochq4BcuOxVfWmdnCoLTlg2MV+hqhOek+W2OhG0Lwg==}
+  /mlly/1.0.0:
+    resolution: {integrity: sha512-QL108Hwt+u9bXdWgOI0dhzZfACovn5Aen4Xvc8Jasd9ouRH4NjnrXEiyP3nVvJo91zPlYjVRckta0Nt2zfoR6g==}
     dependencies:
-      acorn: 8.8.0
-      pathe: 0.3.9
-      pkg-types: 0.3.6
-      ufo: 0.8.5
+      acorn: 8.8.1
+      pathe: 1.0.0
+      pkg-types: 1.0.1
+      ufo: 1.0.0
     dev: true
 
   /mock-socket/9.1.5:
@@ -5415,7 +5885,7 @@ packages:
     resolution: {integrity: sha512-0HjdhYFfdfgFqpjDgdO04fijoTtJvjFVgZJST4LZhepQ8ciMfW5XWzuedVyIW/bRDB3NelyI9f3qZFsjq9s0sA==}
     dependencies:
       '@polkadot/api': 9.8.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5441,6 +5911,10 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: true
+
+  /natural-compare-lite/1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
 
   /natural-compare/1.4.0:
@@ -5525,8 +5999,8 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.10.0
-      semver: 7.3.7
+      is-core-module: 2.11.0
+      semver: 7.3.8
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -5715,12 +6189,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /pathe/0.2.0:
-    resolution: {integrity: sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==}
-    dev: true
-
-  /pathe/0.3.9:
-    resolution: {integrity: sha512-6Y6s0vT112P3jD8dGfuS6r+lpa0qqNrLyHPOwvXMnyNTQaYiwgau2DP3aNDsR13xqtGj7rrPo+jFUATpU6/s+g==}
+  /pathe/1.0.0:
+    resolution: {integrity: sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==}
     dev: true
 
   /pathval/1.1.1:
@@ -5746,12 +6216,12 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /pkg-types/0.3.6:
-    resolution: {integrity: sha512-uQZutkkh6axl1GxDm5/+8ivVdwuJ5pyDGqJeSiIWIUWIqYiK3p9QKozN/Rv6eVvFoeSWkN1uoYeSDBwwBJBtbg==}
+  /pkg-types/1.0.1:
+    resolution: {integrity: sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 0.5.16
-      pathe: 0.3.9
+      mlly: 1.0.0
+      pathe: 1.0.0
     dev: true
 
   /pluralize/8.0.0:
@@ -5764,7 +6234,7 @@ packages:
     dependencies:
       '@polkadot/keyring': 7.9.2_keoxkz6t4n2xq2s5kqoa47ekaq
       '@polkadot/types': 6.12.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - '@polkadot/util'
       - '@polkadot/util-crypto'
@@ -5926,7 +6396,7 @@ packages:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.10.0
+      is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -5950,7 +6420,7 @@ packages:
       inherits: 2.0.4
     dev: false
 
-  /rollup-plugin-dts/5.0.0_aoc4guvlpr5bfeyf2nus4ubkpu:
+  /rollup-plugin-dts/5.0.0_6annma2bj33shm6er7hwi5u4z4:
     resolution: {integrity: sha512-OO8ayCvuJCKaQSShyVTARxGurVVk4ulzbuvz+0zFd1f93vlnWFU5pBMT7HFeS6uj7MvvZLx4kUAarGATSU1+Ng==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -5959,7 +6429,7 @@ packages:
     dependencies:
       magic-string: 0.26.7
       rollup: 3.3.0
-      typescript: 4.8.4
+      typescript: 4.9.3
     optionalDependencies:
       '@babel/code-frame': 7.18.6
     dev: true
@@ -6026,8 +6496,8 @@ packages:
     resolution: {integrity: sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==}
     dev: false
 
-  /scule/0.3.2:
-    resolution: {integrity: sha512-zIvPdjOH8fv8CgrPT5eqtxHQXmPNnV/vHJYffZhE43KZkvULvpCTvOt1HPlFaCZx287INL9qaqrZg34e8NgI4g==}
+  /scule/1.0.0:
+    resolution: {integrity: sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==}
     dev: true
 
   /semver/5.7.1:
@@ -6040,8 +6510,8 @@ packages:
     hasBin: true
     dev: true
 
-  /semver/7.3.7:
-    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
+  /semver/7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -6154,7 +6624,7 @@ packages:
       figures: 3.2.0
       find-up: 5.0.0
       git-semver-tags: 4.1.1
-      semver: 7.3.7
+      semver: 7.3.8
       stringify-package: 1.0.1
       yargs: 16.2.0
     dev: true
@@ -6227,7 +6697,7 @@ packages:
   /strip-literal/0.4.2:
     resolution: {integrity: sha512-pv48ybn4iE1O9RLgCAN0iU4Xv7RlBTiit6DKmMiErbs9x1wH6vXBs45tWc0H5wUIF6TLTrKweqkmYF/iraQKNw==}
     dependencies:
-      acorn: 8.8.0
+      acorn: 8.8.1
     dev: true
 
   /supports-color/5.5.0:
@@ -6339,6 +6809,37 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /ts-node/10.9.1_wup25etrarvlqkprac7h35hj7u:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 18.11.9
+      acorn: 8.8.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -6354,14 +6855,14 @@ packages:
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
-  /tsutils/3.21.0_typescript@4.8.4:
+  /tsutils/3.21.0_typescript@4.9.3:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     dev: true
 
   /tweetnacl/1.0.3:
@@ -6418,13 +6919,13 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript/4.8.4:
-    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+  /typescript/4.9.3:
+    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  /ufo/0.8.5:
-    resolution: {integrity: sha512-e4+UtA5IRO+ha6hYklwj6r7BjiGMxS0O+UaSg9HbaTefg4kMkzj4tXzEBajRR+wkxf+golgAWKzLbytCUDMJAA==}
+  /ufo/1.0.0:
+    resolution: {integrity: sha512-DRty0ZBNlJ2R59y4mEupJRKLbkLQsc4qtxjpQv78AwEDuBkaUogMc2LkeqW3HddFlw6NwnXYfdThEZOiNgkmmQ==}
     dev: true
 
   /uglify-js/3.17.0:
@@ -6444,8 +6945,8 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /unbuild/0.9.4:
-    resolution: {integrity: sha512-IkKPqzazcCNfwTSs5bDRS2bOvg1Zh9gPYQq/ruVarCoM4f7KXclSrcb0jyJiSU/5qhakZ8K5B2CzwX4ZaaVKdQ==}
+  /unbuild/1.0.1:
+    resolution: {integrity: sha512-i2mkbLNFZDJJdpsbg4JflHldKeF3J0K+mLGUdh8jrHBSTHZBw8qFWI7t/AUrGjHxa/O/vkIod65LXu9ktPiUHw==}
     hasBin: true
     dependencies:
       '@rollup/plugin-alias': 4.0.2_rollup@3.3.0
@@ -6456,26 +6957,27 @@ packages:
       '@rollup/pluginutils': 5.0.2_rollup@3.3.0
       chalk: 5.1.2
       consola: 2.15.3
-      defu: 6.1.0
-      esbuild: 0.15.13
+      defu: 6.1.1
+      esbuild: 0.15.14
       globby: 13.1.2
-      hookable: 5.4.1
+      hookable: 5.4.2
       jiti: 1.16.0
       magic-string: 0.26.7
       mkdirp: 1.0.4
-      mkdist: 0.3.13_typescript@4.8.4
-      mlly: 0.5.16
+      mkdist: 1.0.0_typescript@4.9.3
+      mlly: 1.0.0
       mri: 1.2.0
-      pathe: 0.3.9
-      pkg-types: 0.3.6
+      pathe: 1.0.0
+      pkg-types: 1.0.1
       pretty-bytes: 6.0.0
       rimraf: 3.0.2
       rollup: 3.3.0
-      rollup-plugin-dts: 5.0.0_aoc4guvlpr5bfeyf2nus4ubkpu
-      scule: 0.3.2
-      typescript: 4.8.4
-      untyped: 0.5.0
+      rollup-plugin-dts: 5.0.0_6annma2bj33shm6er7hwi5u4z4
+      scule: 1.0.0
+      typescript: 4.9.3
+      untyped: 1.0.0
     transitivePeerDependencies:
+      - sass
       - supports-color
     dev: true
 
@@ -6484,13 +6986,13 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /untyped/0.5.0:
-    resolution: {integrity: sha512-2Sre5A1a7G61bjaAKZnSFaVgbJMwwbbYQpJFH69hAYcDfN7kIaktlSphS02XJilz4+/jR1tsJ5MHo1oMoCezxg==}
+  /untyped/1.0.0:
+    resolution: {integrity: sha512-aBeR3Z51038d7zVzsNShYEdO7u/VCp5R17fxpPXlD2QvG9g6uVJ+JM+zMJ7KFPIt1BNf3I6bU6PhAlsAFkIfdA==}
     dependencies:
-      '@babel/core': 7.19.3
-      '@babel/standalone': 7.19.3
-      '@babel/types': 7.19.3
-      scule: 0.3.2
+      '@babel/core': 7.20.2
+      '@babel/standalone': 7.20.4
+      '@babel/types': 7.20.2
+      scule: 1.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6527,6 +7029,10 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
     dev: false
+
+  /v8-compile-cache-lib/3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
 
   /v8-to-istanbul/9.0.1:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
@@ -6571,8 +7077,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.25.1:
-    resolution: {integrity: sha512-eH74h6MkuEgsqR4mAQZeMK9O0PROiKY+i+1GMz/fBi5A3L2ml5U7JQs7LfPU7+uWUziZyLHagl+rkyfR8SLhlA==}
+  /vitest/0.25.2:
+    resolution: {integrity: sha512-qqkzfzglEFbQY7IGkgSJkdOhoqHjwAao/OrphnHboeYHC5JzsVFoLCaB2lnAy8krhj7sbrFTVRApzpkTOeuDWQ==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -6595,8 +7101,8 @@ packages:
     dependencies:
       '@types/chai': 4.3.3
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.7.14
-      acorn: 8.8.0
+      '@types/node': 18.11.9
+      acorn: 8.8.1
       acorn-walk: 8.2.0
       chai: 4.3.6
       debug: 4.3.4
@@ -6615,20 +7121,20 @@ packages:
       - terser
     dev: true
 
-  /vue-eslint-parser/9.0.3_eslint@8.27.0:
+  /vue-eslint-parser/9.0.3_eslint@8.28.0:
     resolution: {integrity: sha512-yL+ZDb+9T0ELG4VIFo/2anAOz8SvBdlqEnQnvJ3M7Scq56DvtjY0VY88bByRZB0D4J0u8olBcfrXTVONXsh4og==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
       debug: 4.3.4
-      eslint: 8.27.0
+      eslint: 8.28.0
       eslint-scope: 7.1.1
       eslint-visitor-keys: 3.3.0
       espree: 9.4.0
       esquery: 1.4.0
       lodash: 4.17.21
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6775,6 +7281,11 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
+    dev: true
+
+  /yn/3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
     dev: true
 
   /yocto-queue/0.1.0:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * as xcmPallet from './pallets/xcmPallet'
 export * as openChannels from './pallets/parasSudoWrapper'
 export * as closeChannels from './pallets/hrmp'
+export * as assets from './pallets/assets'

--- a/src/maps/assets.json
+++ b/src/maps/assets.json
@@ -1,0 +1,2194 @@
+{
+    "Acala": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "aUSD",
+            "ACA",
+            "TAP",
+            "LcDOT",
+            "LDOT",
+            "DOT"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "0",
+                "symbol": "tDOT"
+            },
+            {
+                "assetId": "8",
+                "symbol": "EQD"
+            },
+            {
+                "assetId": "4",
+                "symbol": "INTR"
+            },
+            {
+                "assetId": "6",
+                "symbol": "WETH"
+            },
+            {
+                "assetId": "0x07df96d1341a7d16ba1ad431e2c847d978bc2bce",
+                "symbol": "USDCet"
+            },
+            {
+                "assetId": "2",
+                "symbol": "ASTR"
+            },
+            {
+                "assetId": "9",
+                "symbol": "PHA"
+            },
+            {
+                "assetId": "1",
+                "symbol": "PARA"
+            },
+            {
+                "assetId": "0",
+                "symbol": "GLMR"
+            },
+            {
+                "assetId": "5",
+                "symbol": "WBTC"
+            },
+            {
+                "assetId": "0x54a37a01cd75b616d63e0ab665bffdb0143c52ae",
+                "symbol": "DAI"
+            },
+            {
+                "assetId": "7",
+                "symbol": "EQ"
+            },
+            {
+                "assetId": "3",
+                "symbol": "IBTC"
+            }
+        ]
+    },
+    "Astar": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "ASTR"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "18446744073709551623",
+                "symbol": "BNC"
+            },
+            {
+                "assetId": "18446744073709551619",
+                "symbol": "GLMR"
+            },
+            {
+                "assetId": "1337",
+                "symbol": "XC20"
+            },
+            {
+                "assetId": "1334",
+                "symbol": "TOK"
+            },
+            {
+                "assetId": "1328",
+                "symbol": "ALGM"
+            },
+            {
+                "assetId": "1333",
+                "symbol": "ASTR"
+            },
+            {
+                "assetId": "18446744073709551625",
+                "symbol": "CLV"
+            },
+            {
+                "assetId": "18446744073709551620",
+                "symbol": "IBTC"
+            },
+            {
+                "assetId": "18446744073709551621",
+                "symbol": "INTR"
+            },
+            {
+                "assetId": "18446744073709551622",
+                "symbol": "PHA"
+            },
+            {
+                "assetId": "340282366920938463463374607431768211455",
+                "symbol": "DOT"
+            },
+            {
+                "assetId": "1335",
+                "symbol": "MDOT"
+            },
+            {
+                "assetId": "18446744073709551616",
+                "symbol": "ACA"
+            },
+            {
+                "assetId": "18446744073709551624",
+                "symbol": "vDOT"
+            },
+            {
+                "assetId": "18446744073709551618",
+                "symbol": "LDOT"
+            },
+            {
+                "assetId": "18446744073709551617",
+                "symbol": "aUSD"
+            },
+            {
+                "assetId": "1336",
+                "symbol": "TDOT"
+            },
+            {
+                "assetId": "1329",
+                "symbol": "PPC"
+            },
+            {
+                "assetId": "4294969280",
+                "symbol": "USDT"
+            },
+            {
+                "assetId": "1330",
+                "symbol": "MMC"
+            },
+            {
+                "assetId": "1331",
+                "symbol": "sDOT"
+            },
+            {
+                "assetId": "1332",
+                "symbol": "sDOT"
+            }
+        ]
+    },
+    "BifrostPolkadot": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "ASG",
+            "BNC",
+            "KUSD",
+            "DOT",
+            "KSM",
+            "ETH",
+            "KAR",
+            "ZLK",
+            "PHA",
+            "RMRK",
+            "MOVR"
+        ],
+        "otherAssets": []
+    },
+    "Bitgreen": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "BBB"
+        ],
+        "otherAssets": []
+    },
+    "Centrifuge": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "CFG"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "3",
+                "symbol": "aUSD"
+            },
+            {
+                "assetId": "1",
+                "symbol": "USDT"
+            },
+            {
+                "assetId": "4",
+                "symbol": "GLMR"
+            },
+            {
+                "assetId": "2",
+                "symbol": "xcUSDC"
+            }
+        ]
+    },
+    "Clover": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "CLV"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "11",
+                "symbol": "PARA"
+            },
+            {
+                "assetId": "12",
+                "symbol": "ASTR"
+            }
+        ]
+    },
+    "ComposableFinance": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "LAYR"
+        ],
+        "otherAssets": []
+    },
+    "Darwinia": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "RING"
+        ],
+        "otherAssets": []
+    },
+    "Efinity": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "EFI"
+        ],
+        "otherAssets": []
+    },
+    "Equilibrium": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "TOKEN"
+        ],
+        "otherAssets": []
+    },
+    "HydraDX": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "HDX"
+        ],
+        "otherAssets": []
+    },
+    "Interlay": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "INTR",
+            "IBTC",
+            "DOT",
+            "KINT",
+            "KBTC",
+            "KSM"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "1",
+                "symbol": "LDOT"
+            },
+            {
+                "assetId": "2",
+                "symbol": "USDT"
+            }
+        ]
+    },
+    "Kilt": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "KILT"
+        ],
+        "otherAssets": []
+    },
+    "Kapex": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "KPX"
+        ],
+        "otherAssets": []
+    },
+    "Kylin": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "KYL"
+        ],
+        "otherAssets": []
+    },
+    "Litentry": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "LIT"
+        ],
+        "otherAssets": []
+    },
+    "Moonbeam": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "GLMR"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "125699734534028342599692732320197985871",
+                "symbol": "xcRING"
+            },
+            {
+                "assetId": "224077081838586484055667086558292981199",
+                "symbol": "xcASTR"
+            },
+            {
+                "assetId": "110021739665376159354538090254163045594",
+                "symbol": "xcaUSD"
+            },
+            {
+                "assetId": "311091173110107856861649819128533077277",
+                "symbol": "xcUSDT"
+            },
+            {
+                "assetId": "120637696315203257380661607956669368914",
+                "symbol": "xcIBTC"
+            },
+            {
+                "assetId": "101170542313601871197860408087030232491",
+                "symbol": "xcINTR"
+            },
+            {
+                "assetId": "165823357460190568952172802245839421906",
+                "symbol": "xcBNC"
+            },
+            {
+                "assetId": "32615670524745285411807346420584982855",
+                "symbol": "xcPARA"
+            },
+            {
+                "assetId": "42259045809535163221576417993425387648",
+                "symbol": "xcDOT"
+            },
+            {
+                "assetId": "224821240862170613278369189818311486111",
+                "symbol": "xcACA"
+            },
+            {
+                "assetId": "132685552157663328694213725410064821485",
+                "symbol": "xcPHA"
+            }
+        ]
+    },
+    "OriginTrail": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "OTP"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "1",
+                "symbol": "TRAC"
+            }
+        ]
+    },
+    "Parallel": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "PARA"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "6002",
+                "symbol": "LP-DOT/PARA"
+            },
+            {
+                "assetId": "6007",
+                "symbol": "LP-DOT/cDOT-8/15"
+            },
+            {
+                "assetId": "110",
+                "symbol": "LDOT"
+            },
+            {
+                "assetId": "1001",
+                "symbol": "sDOT"
+            },
+            {
+                "assetId": "120",
+                "symbol": "INTR"
+            },
+            {
+                "assetId": "108",
+                "symbol": "ACA"
+            },
+            {
+                "assetId": "200070014",
+                "symbol": "cDOT-7/14"
+            },
+            {
+                "assetId": "6009",
+                "symbol": "LP-PHA/PARA"
+            },
+            {
+                "assetId": "101",
+                "symbol": "DOT"
+            },
+            {
+                "assetId": "6005",
+                "symbol": "LP-DOT/cDOT-7/14"
+            },
+            {
+                "assetId": "200080015",
+                "symbol": "cDOT-8/15"
+            },
+            {
+                "assetId": "122",
+                "symbol": "IBTC"
+            },
+            {
+                "assetId": "6016",
+                "symbol": "LP-INTR/PARA"
+            },
+            {
+                "assetId": "6004",
+                "symbol": "LP-DOT/cDOT-6/13"
+            },
+            {
+                "assetId": "6013",
+                "symbol": "LP-PARA/cDOT-8/15"
+            },
+            {
+                "assetId": "104",
+                "symbol": "AUSD"
+            },
+            {
+                "assetId": "6003",
+                "symbol": "LP-DOT/sDOT"
+            },
+            {
+                "assetId": "6017",
+                "symbol": "LP-IBTC/PARA"
+            },
+            {
+                "assetId": "102",
+                "symbol": "USDT"
+            },
+            {
+                "assetId": "106",
+                "symbol": "lcDOT"
+            },
+            {
+                "assetId": "114",
+                "symbol": "GLMR"
+            },
+            {
+                "assetId": "6008",
+                "symbol": "LP-GLMR/PARA"
+            },
+            {
+                "assetId": "130",
+                "symbol": "CLV"
+            },
+            {
+                "assetId": "4294957296",
+                "symbol": "DOT_U"
+            },
+            {
+                "assetId": "112",
+                "symbol": "ASTR"
+            },
+            {
+                "assetId": "200100017",
+                "symbol": "cDOT-10/17"
+            },
+            {
+                "assetId": "6011",
+                "symbol": "LP-lcDOT/PARA"
+            },
+            {
+                "assetId": "6012",
+                "symbol": "LP-PARA/cDOT-7/14"
+            },
+            {
+                "assetId": "6010",
+                "symbol": "LP-USDT/PARA"
+            },
+            {
+                "assetId": "200060013",
+                "symbol": "cDOT-6/13"
+            },
+            {
+                "assetId": "115",
+                "symbol": "PHA"
+            },
+            {
+                "assetId": "200090016",
+                "symbol": "cDOT-9/16"
+            },
+            {
+                "assetId": "6014",
+                "symbol": "LP-ACA/PARA"
+            },
+            {
+                "assetId": "6006",
+                "symbol": "LP-PARA/cDOT-6/13"
+            },
+            {
+                "assetId": "6015",
+                "symbol": "LP-LDOT/PARA"
+            }
+        ]
+    },
+    "Phala": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "PHA"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "0",
+                "symbol": "DOT"
+            },
+            {
+                "assetId": "4",
+                "symbol": "LDOT"
+            },
+            {
+                "assetId": "6",
+                "symbol": "ASTR"
+            },
+            {
+                "assetId": "2",
+                "symbol": "PARA"
+            },
+            {
+                "assetId": "5",
+                "symbol": "ACA"
+            },
+            {
+                "assetId": "7",
+                "symbol": "RING"
+            },
+            {
+                "assetId": "1",
+                "symbol": "GLMR"
+            },
+            {
+                "assetId": "3",
+                "symbol": "AUSD"
+            }
+        ]
+    },
+    "Statemint": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "DOT"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "100",
+                "symbol": "WETH"
+            },
+            {
+                "assetId": "123",
+                "symbol": "123"
+            },
+            {
+                "assetId": "4",
+                "symbol": "EFI"
+            },
+            {
+                "assetId": "21",
+                "symbol": "WBTC"
+            },
+            {
+                "assetId": "999",
+                "symbol": "gold"
+            },
+            {
+                "assetId": "101",
+                "symbol": "DOTMA"
+            },
+            {
+                "assetId": "77",
+                "symbol": "TRQ"
+            },
+            {
+                "assetId": "2",
+                "symbol": "BTC"
+            },
+            {
+                "assetId": "868367",
+                "symbol": "VSC"
+            },
+            {
+                "assetId": "7",
+                "symbol": "lucky7"
+            },
+            {
+                "assetId": "1984",
+                "symbol": "USDt"
+            },
+            {
+                "assetId": "20090103",
+                "symbol": "BTC"
+            },
+            {
+                "assetId": "777",
+                "symbol": "777"
+            },
+            {
+                "assetId": "8",
+                "symbol": "JOE"
+            },
+            {
+                "assetId": "1",
+                "symbol": "no1"
+            },
+            {
+                "assetId": "3",
+                "symbol": "DOT"
+            },
+            {
+                "assetId": "666",
+                "symbol": "DANGER"
+            },
+            {
+                "assetId": "9",
+                "symbol": "PINT"
+            },
+            {
+                "assetId": "862812",
+                "symbol": "CUBO"
+            }
+        ]
+    },
+    "Unique": {
+        "relayChainAssetSymbol": "DOT",
+        "nativeAssets": [
+            "UNQ"
+        ],
+        "otherAssets": []
+    },
+    "Altair": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "AIR"
+        ],
+        "otherAssets": []
+    },
+    "Amplitude": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "AMPE"
+        ],
+        "otherAssets": []
+    },
+    "Bajun": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "BAJU"
+        ],
+        "otherAssets": []
+    },
+    "Basilisk": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "BSX"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "13",
+                "symbol": "DAI"
+            },
+            {
+                "assetId": "1",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "9",
+                "symbol": "USDCet"
+            },
+            {
+                "assetId": "2",
+                "symbol": "aUSD"
+            },
+            {
+                "assetId": "10",
+                "symbol": "wETH"
+            },
+            {
+                "assetId": "0",
+                "symbol": "BSX"
+            },
+            {
+                "assetId": "6",
+                "symbol": "TNKR"
+            },
+            {
+                "assetId": "11",
+                "symbol": "wBTC"
+            },
+            {
+                "assetId": "12",
+                "symbol": "USDT"
+            }
+        ]
+    },
+    "BifrostKusama": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "BNC",
+            "KUSD",
+            "DOT",
+            "KSM",
+            "KAR",
+            "ZLK",
+            "PHA",
+            "RMRK",
+            "MOVR"
+        ],
+        "otherAssets": []
+    },
+    "Calamari": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "KMA"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "10",
+                "symbol": "LKSM"
+            },
+            {
+                "assetId": "11",
+                "symbol": "MOVR"
+            },
+            {
+                "assetId": "13",
+                "symbol": "PHA"
+            },
+            {
+                "assetId": "8",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "12",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "9",
+                "symbol": "AUSD"
+            }
+        ]
+    },
+    "Crab": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "CRAB"
+        ],
+        "otherAssets": []
+    },
+    "CrustShadow": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "CSM"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "16797826370226091782818345603793389938",
+                "symbol": "SDN"
+            },
+            {
+                "assetId": "108036400430056508975016746969135344601",
+                "symbol": "XRT"
+            },
+            {
+                "assetId": "173481220575862801646329923366065693029",
+                "symbol": "CRAB"
+            },
+            {
+                "assetId": "214920334981412447805621250067209749032",
+                "symbol": "AUSD"
+            },
+            {
+                "assetId": "232263652204149413431520870009560565298",
+                "symbol": "MOVR"
+            },
+            {
+                "assetId": "10810581592933651521121702237638664357",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "319623561105283008236062145480775032445",
+                "symbol": "BNC"
+            }
+        ]
+    },
+    "Dorafactory": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "DORA"
+        ],
+        "otherAssets": []
+    },
+    "Encointer": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "KSM"
+        ],
+        "otherAssets": []
+    },
+    "GM": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "FREN",
+            "GM",
+            "GN"
+        ],
+        "otherAssets": []
+    },
+    "Imbue": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "IMBU"
+        ],
+        "otherAssets": []
+    },
+    "Integritee": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "TEER"
+        ],
+        "otherAssets": []
+    },
+    "InvArchTinker": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "TNKR"
+        ],
+        "otherAssets": []
+    },
+    "Kico": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "KICO"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "100",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "0",
+                "symbol": "KICO"
+            },
+            {
+                "assetId": "10",
+                "symbol": "aUSD"
+            },
+            {
+                "assetId": "11",
+                "symbol": "SOL"
+            },
+            {
+                "assetId": "4000000004",
+                "symbol": "aUSD-KSM"
+            },
+            {
+                "assetId": "4000000000",
+                "symbol": "KICO-aUSD"
+            },
+            {
+                "assetId": "4000000001",
+                "symbol": "KSM-KICO"
+            },
+            {
+                "assetId": "13",
+                "symbol": "LIKE"
+            },
+            {
+                "assetId": "102",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "4000000002",
+                "symbol": "KAR-KICO"
+            },
+            {
+                "assetId": "4000000003",
+                "symbol": "KAR-aUSD"
+            },
+            {
+                "assetId": "12",
+                "symbol": "LT"
+            }
+        ]
+    },
+    "Kabocha": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "KAB"
+        ],
+        "otherAssets": []
+    },
+    "Karura": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "LKSM",
+            "KAR",
+            "BNC",
+            "TAI",
+            "PHA",
+            "KINT",
+            "VSKSM",
+            "KSM",
+            "aUSD",
+            "KBTC"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "10",
+                "symbol": "KMA"
+            },
+            {
+                "assetId": "14",
+                "symbol": "GENS"
+            },
+            {
+                "assetId": "0",
+                "symbol": "taiKSM"
+            },
+            {
+                "assetId": "19",
+                "symbol": "LT"
+            },
+            {
+                "assetId": "8",
+                "symbol": "TEER"
+            },
+            {
+                "assetId": "16",
+                "symbol": "TUR"
+            },
+            {
+                "assetId": "4",
+                "symbol": "HKO"
+            },
+            {
+                "assetId": "6",
+                "symbol": "KICO"
+            },
+            {
+                "assetId": "2",
+                "symbol": "QTZ"
+            },
+            {
+                "assetId": "20",
+                "symbol": "LIT"
+            },
+            {
+                "assetId": "9",
+                "symbol": "NEER"
+            },
+            {
+                "assetId": "1",
+                "symbol": "ARIS"
+            },
+            {
+                "assetId": "0",
+                "symbol": "RMRK"
+            },
+            {
+                "assetId": "5",
+                "symbol": "CSM"
+            },
+            {
+                "assetId": "0x1f3a10587a20114ea25ba1b388ee2dd4a337ce27",
+                "symbol": "USDCet"
+            },
+            {
+                "assetId": "17",
+                "symbol": "PCHU"
+            },
+            {
+                "assetId": "13",
+                "symbol": "CRAB"
+            },
+            {
+                "assetId": "0x4bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71",
+                "symbol": "DAI"
+            },
+            {
+                "assetId": "11",
+                "symbol": "BSX"
+            },
+            {
+                "assetId": "12",
+                "symbol": "AIR"
+            },
+            {
+                "assetId": "0xe20683ad1ed8bbeed7e1ae74be10f19d8045b530",
+                "symbol": "waUSD"
+            },
+            {
+                "assetId": "7",
+                "symbol": "USDT"
+            },
+            {
+                "assetId": "18",
+                "symbol": "SDN"
+            },
+            {
+                "assetId": "1",
+                "symbol": "3USD"
+            },
+            {
+                "assetId": "15",
+                "symbol": "EQD"
+            },
+            {
+                "assetId": "3",
+                "symbol": "MOVR"
+            }
+        ]
+    },
+    "Khala": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "PHA"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "0",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "10",
+                "symbol": "TUR"
+            },
+            {
+                "assetId": "4",
+                "symbol": "aUSD"
+            },
+            {
+                "assetId": "11",
+                "symbol": "CRAB"
+            },
+            {
+                "assetId": "6",
+                "symbol": "MOVR"
+            },
+            {
+                "assetId": "2",
+                "symbol": "BNC"
+            },
+            {
+                "assetId": "5",
+                "symbol": "BSX"
+            },
+            {
+                "assetId": "7",
+                "symbol": "HKO"
+            },
+            {
+                "assetId": "8",
+                "symbol": "KMA"
+            },
+            {
+                "assetId": "1",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "12",
+                "symbol": "SDN"
+            },
+            {
+                "assetId": "3",
+                "symbol": "ZLK"
+            },
+            {
+                "assetId": "9",
+                "symbol": "BSX"
+            }
+        ]
+    },
+    "Kintsugi": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "KINT",
+            "KBTC",
+            "KSM",
+            "INTR",
+            "IBTC",
+            "DOT"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "1",
+                "symbol": "AUSD"
+            },
+            {
+                "assetId": "2",
+                "symbol": "LKSM"
+            },
+            {
+                "assetId": "3",
+                "symbol": "USDT"
+            }
+        ]
+    },
+    "Listen": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "LT"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "100",
+                "symbol": "KT"
+            },
+            {
+                "assetId": "0",
+                "symbol": "LT"
+            },
+            {
+                "assetId": "10",
+                "symbol": "KICO"
+            },
+            {
+                "assetId": "129",
+                "symbol": "aUSD"
+            },
+            {
+                "assetId": "2",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "5",
+                "symbol": "USDT"
+            },
+            {
+                "assetId": "128",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "131",
+                "symbol": "LKSM"
+            },
+            {
+                "assetId": "1",
+                "symbol": "LIKE"
+            }
+        ]
+    },
+    "Litmus": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "LIT"
+        ],
+        "otherAssets": []
+    },
+    "Mangata": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "MGX"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "7",
+                "symbol": "TUR"
+            },
+            {
+                "assetId": "5",
+                "symbol": "TKN0x00000004-TKN0x00000000"
+            },
+            {
+                "assetId": "8",
+                "symbol": "TKN0x00000000-TKN0x00000007"
+            },
+            {
+                "assetId": "1",
+                "symbol": "ETH"
+            },
+            {
+                "assetId": "9",
+                "symbol": "TKN0x00000004-TKN0x00000007"
+            },
+            {
+                "assetId": "10",
+                "symbol": "TKN0x00000005-TKN0x00000000"
+            },
+            {
+                "assetId": "0",
+                "symbol": "MGX"
+            },
+            {
+                "assetId": "6",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "11",
+                "symbol": "IMBU"
+            },
+            {
+                "assetId": "3",
+                "symbol": "TKN0x00000000-TKN0x00000002"
+            },
+            {
+                "assetId": "4",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "12",
+                "symbol": "TKN0x00000000-TKN0x0000000B"
+            }
+        ]
+    },
+    "Moonriver": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "MOVR"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "108457044225666871745333730479173774551",
+                "symbol": "xcCSM"
+            },
+            {
+                "assetId": "16797826370226091782818345603793389938",
+                "symbol": "xcSDN"
+            },
+            {
+                "assetId": "76100021443485661246318545281171740067",
+                "symbol": "xcHKO"
+            },
+            {
+                "assetId": "328179947973504579459046439826496046832",
+                "symbol": "xcKBTC"
+            },
+            {
+                "assetId": "108036400430056508975016746969135344601",
+                "symbol": "xcXRT"
+            },
+            {
+                "assetId": "213357169630950964874127107356898319277",
+                "symbol": "xcKMA"
+            },
+            {
+                "assetId": "65216491554813189869575508812319036608",
+                "symbol": "xcLIT"
+            },
+            {
+                "assetId": "173481220575862801646329923366065693029",
+                "symbol": "xcCRAB"
+            },
+            {
+                "assetId": "189307976387032586987344677431204943363",
+                "symbol": "xcPHA"
+            },
+            {
+                "assetId": "214920334981412447805621250067209749032",
+                "symbol": "xcAUSD"
+            },
+            {
+                "assetId": "175400718394635817552109270754364440562",
+                "symbol": "xcKINT"
+            },
+            {
+                "assetId": "105075627293246237499203909093923548958",
+                "symbol": "xcTEER"
+            },
+            {
+                "assetId": "311091173110107856861649819128533077277",
+                "symbol": "xcUSDT"
+            },
+            {
+                "assetId": "182365888117048807484804376330534607370",
+                "symbol": "xcRMRK"
+            },
+            {
+                "assetId": "42259045809535163221576417993425387648",
+                "symbol": "xcKSM"
+            },
+            {
+                "assetId": "10810581592933651521121702237638664357",
+                "symbol": "xcKAR"
+            },
+            {
+                "assetId": "319623561105283008236062145480775032445",
+                "symbol": "xcBNC"
+            }
+        ]
+    },
+    "ParallelHeiko": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "HKO"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "100",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "123",
+                "symbol": "GENS"
+            },
+            {
+                "assetId": "121",
+                "symbol": "KBTC"
+            },
+            {
+                "assetId": "5007",
+                "symbol": "LP-USDT/HKO"
+            },
+            {
+                "assetId": "100210028",
+                "symbol": "cKSM-21/28"
+            },
+            {
+                "assetId": "125",
+                "symbol": "TUR"
+            },
+            {
+                "assetId": "5002",
+                "symbol": "LP-KSM/HKO"
+            },
+            {
+                "assetId": "103",
+                "symbol": "AUSD"
+            },
+            {
+                "assetId": "109",
+                "symbol": "LKSM"
+            },
+            {
+                "assetId": "111",
+                "symbol": "SDN"
+            },
+            {
+                "assetId": "5005",
+                "symbol": "LP-MOVR/HKO"
+            },
+            {
+                "assetId": "119",
+                "symbol": "KINT"
+            },
+            {
+                "assetId": "100150022",
+                "symbol": "cKSM-15/22"
+            },
+            {
+                "assetId": "5004",
+                "symbol": "LP-KSM/cKSM-20/27"
+            },
+            {
+                "assetId": "102",
+                "symbol": "USDT"
+            },
+            {
+                "assetId": "100230030",
+                "symbol": "cKSM-23/30"
+            },
+            {
+                "assetId": "5006",
+                "symbol": "LP-PHA/HKO"
+            },
+            {
+                "assetId": "5011",
+                "symbol": "LP-KBTC/HKO"
+            },
+            {
+                "assetId": "4294957295",
+                "symbol": "KSM_U"
+            },
+            {
+                "assetId": "1000",
+                "symbol": "sKSM"
+            },
+            {
+                "assetId": "113",
+                "symbol": "MOVR"
+            },
+            {
+                "assetId": "115",
+                "symbol": "PHA"
+            },
+            {
+                "assetId": "5003",
+                "symbol": "LP-KSM/sKSM"
+            },
+            {
+                "assetId": "100220029",
+                "symbol": "cKSM-22/29"
+            },
+            {
+                "assetId": "107",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "5008",
+                "symbol": "LP-KAR/HKO"
+            },
+            {
+                "assetId": "5009",
+                "symbol": "LP-LKSM/HKO"
+            },
+            {
+                "assetId": "5010",
+                "symbol": "LP-KINT/HKO"
+            },
+            {
+                "assetId": "100200027",
+                "symbol": "cKSM-20/27"
+            }
+        ]
+    },
+    "Picasso": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "PICA"
+        ],
+        "otherAssets": []
+    },
+    "Pichiu": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "PCHU"
+        ],
+        "otherAssets": []
+    },
+    "Pioneer": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "NEER"
+        ],
+        "otherAssets": []
+    },
+    "Quartz": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "QTZ"
+        ],
+        "otherAssets": []
+    },
+    "Robonomics": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "XRT"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "4294967292",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "4294967295",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "4294967291",
+                "symbol": "CSM"
+            },
+            {
+                "assetId": "4294967293",
+                "symbol": "LKSM"
+            },
+            {
+                "assetId": "4294967294",
+                "symbol": "AUSD"
+            }
+        ]
+    },
+    "Sora": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [],
+        "otherAssets": []
+    },
+    "Shiden": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "SDN"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "18446744073709551623",
+                "symbol": "PHA"
+            },
+            {
+                "assetId": "18446744073709551619",
+                "symbol": "LKSM"
+            },
+            {
+                "assetId": "314",
+                "symbol": "BAR"
+            },
+            {
+                "assetId": "18446744073709551620",
+                "symbol": "MOVR"
+            },
+            {
+                "assetId": "18446744073709551621",
+                "symbol": "KBTC"
+            },
+            {
+                "assetId": "18446744073709551622",
+                "symbol": "KINT"
+            },
+            {
+                "assetId": "312",
+                "symbol": "XCT"
+            },
+            {
+                "assetId": "313",
+                "symbol": "SDG"
+            },
+            {
+                "assetId": "340282366920938463463374607431768211455",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "18446744073709551616",
+                "symbol": "aUSD"
+            },
+            {
+                "assetId": "18446744073709551624",
+                "symbol": "CSM"
+            },
+            {
+                "assetId": "18446744073709551618",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "311",
+                "symbol": "SYG"
+            },
+            {
+                "assetId": "18446744073709551626",
+                "symbol": "SKU"
+            },
+            {
+                "assetId": "4294969280",
+                "symbol": "USDT"
+            },
+            {
+                "assetId": "18446744073709551628",
+                "symbol": "vKSM"
+            },
+            {
+                "assetId": "18446744073709551627",
+                "symbol": "BNC"
+            }
+        ]
+    },
+    "Snow": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "ICZ"
+        ],
+        "otherAssets": []
+    },
+    "Statemine": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "KSM"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "9999",
+                "symbol": "BTC"
+            },
+            {
+                "assetId": "100",
+                "symbol": "Chralt"
+            },
+            {
+                "assetId": "123",
+                "symbol": "NFT"
+            },
+            {
+                "assetId": "9000",
+                "symbol": "KPOTS"
+            },
+            {
+                "assetId": "1155",
+                "symbol": "WITEK"
+            },
+            {
+                "assetId": "69420",
+                "symbol": "CHAOS"
+            },
+            {
+                "assetId": "47",
+                "symbol": "EUR"
+            },
+            {
+                "assetId": "6789",
+                "symbol": "VHM"
+            },
+            {
+                "assetId": "50",
+                "symbol": "PROMO"
+            },
+            {
+                "assetId": "420",
+                "symbol": "BLAZE"
+            },
+            {
+                "assetId": "0",
+                "symbol": "DOG"
+            },
+            {
+                "assetId": "10",
+                "symbol": "USDC"
+            },
+            {
+                "assetId": "1111",
+                "symbol": "MTVD"
+            },
+            {
+                "assetId": "300",
+                "symbol": "PWS"
+            },
+            {
+                "assetId": "4",
+                "symbol": "HAPPY"
+            },
+            {
+                "assetId": "21",
+                "symbol": "ELEV"
+            },
+            {
+                "assetId": "333",
+                "symbol": "Token"
+            },
+            {
+                "assetId": "28",
+                "symbol": "LAC"
+            },
+            {
+                "assetId": "20",
+                "symbol": "BFKK"
+            },
+            {
+                "assetId": "2048",
+                "symbol": "RWS"
+            },
+            {
+                "assetId": "377",
+                "symbol": "KAA"
+            },
+            {
+                "assetId": "95834",
+                "symbol": "LUL"
+            },
+            {
+                "assetId": "999",
+                "symbol": "CBDC"
+            },
+            {
+                "assetId": "30",
+                "symbol": "GOL"
+            },
+            {
+                "assetId": "677",
+                "symbol": "GRB"
+            },
+            {
+                "assetId": "39",
+                "symbol": "DSCAN"
+            },
+            {
+                "assetId": "101",
+                "symbol": "---"
+            },
+            {
+                "assetId": "38",
+                "symbol": "ENT"
+            },
+            {
+                "assetId": "46",
+                "symbol": "FAN"
+            },
+            {
+                "assetId": "99",
+                "symbol": "BITCOIN"
+            },
+            {
+                "assetId": "7777",
+                "symbol": "lucky7"
+            },
+            {
+                "assetId": "168",
+                "symbol": "Tokens"
+            },
+            {
+                "assetId": "2077",
+                "symbol": "XRT"
+            },
+            {
+                "assetId": "16",
+                "symbol": "ARIS"
+            },
+            {
+                "assetId": "11",
+                "symbol": "USDT"
+            },
+            {
+                "assetId": "224",
+                "symbol": "SIK"
+            },
+            {
+                "assetId": "138",
+                "symbol": "Abc"
+            },
+            {
+                "assetId": "75",
+                "symbol": "cipher"
+            },
+            {
+                "assetId": "111",
+                "symbol": "NO1"
+            },
+            {
+                "assetId": "66",
+                "symbol": "DAI"
+            },
+            {
+                "assetId": "14",
+                "symbol": "DOT"
+            },
+            {
+                "assetId": "360",
+                "symbol": "uni"
+            },
+            {
+                "assetId": "6",
+                "symbol": "ZKPD"
+            },
+            {
+                "assetId": "19",
+                "symbol": "SHOT"
+            },
+            {
+                "assetId": "1607",
+                "symbol": "STRGZN"
+            },
+            {
+                "assetId": "383",
+                "symbol": "KODA"
+            },
+            {
+                "assetId": "42069",
+                "symbol": "INTRN"
+            },
+            {
+                "assetId": "88888",
+                "symbol": "BAILEGO"
+            },
+            {
+                "assetId": "4206969",
+                "symbol": "SHIB"
+            },
+            {
+                "assetId": "2021",
+                "symbol": "WAVE"
+            },
+            {
+                "assetId": "1107",
+                "symbol": "HOLIC"
+            },
+            {
+                "assetId": "77",
+                "symbol": "Crypto"
+            },
+            {
+                "assetId": "35",
+                "symbol": "LUCKY"
+            },
+            {
+                "assetId": "36",
+                "symbol": "RRT"
+            },
+            {
+                "assetId": "31",
+                "symbol": "ki"
+            },
+            {
+                "assetId": "33",
+                "symbol": "BUSSY"
+            },
+            {
+                "assetId": "41",
+                "symbol": "GOOSE"
+            },
+            {
+                "assetId": "71",
+                "symbol": "OAK"
+            },
+            {
+                "assetId": "44",
+                "symbol": "ADVNCE"
+            },
+            {
+                "assetId": "11111",
+                "symbol": "KVC"
+            },
+            {
+                "assetId": "15",
+                "symbol": "Web3"
+            },
+            {
+                "assetId": "3721",
+                "symbol": "fast"
+            },
+            {
+                "assetId": "374",
+                "symbol": "wETH"
+            },
+            {
+                "assetId": "40",
+                "symbol": "ERIC"
+            },
+            {
+                "assetId": "2",
+                "symbol": "PNN"
+            },
+            {
+                "assetId": "117",
+                "symbol": "TNKR"
+            },
+            {
+                "assetId": "70",
+                "symbol": "MAR"
+            },
+            {
+                "assetId": "13",
+                "symbol": "LN"
+            },
+            {
+                "assetId": "2049",
+                "symbol": "Android"
+            },
+            {
+                "assetId": "32",
+                "symbol": "FAV"
+            },
+            {
+                "assetId": "188",
+                "symbol": "ZLK"
+            },
+            {
+                "assetId": "27",
+                "symbol": "RUNE"
+            },
+            {
+                "assetId": "49",
+                "symbol": "DIAN"
+            },
+            {
+                "assetId": "1999",
+                "symbol": "ADVERT2"
+            },
+            {
+                "assetId": "314159",
+                "symbol": "RTT"
+            },
+            {
+                "assetId": "29",
+                "symbol": "CODES"
+            },
+            {
+                "assetId": "42",
+                "symbol": "NRNF"
+            },
+            {
+                "assetId": "102",
+                "symbol": "DRX"
+            },
+            {
+                "assetId": "80815",
+                "symbol": "KSMFS"
+            },
+            {
+                "assetId": "43",
+                "symbol": "TTT"
+            },
+            {
+                "assetId": "7777777",
+                "symbol": "king"
+            },
+            {
+                "assetId": "365",
+                "symbol": "time"
+            },
+            {
+                "assetId": "5",
+                "symbol": "BEER"
+            },
+            {
+                "assetId": "18",
+                "symbol": "HEI"
+            },
+            {
+                "assetId": "7",
+                "symbol": "DOS"
+            },
+            {
+                "assetId": "26",
+                "symbol": "BUNGA"
+            },
+            {
+                "assetId": "8848",
+                "symbol": "top"
+            },
+            {
+                "assetId": "3077",
+                "symbol": "ACT"
+            },
+            {
+                "assetId": "87",
+                "symbol": "XEXR"
+            },
+            {
+                "assetId": "1984",
+                "symbol": "USDt"
+            },
+            {
+                "assetId": "1688",
+                "symbol": "ali"
+            },
+            {
+                "assetId": "1123",
+                "symbol": "XEN"
+            },
+            {
+                "assetId": "4294967291",
+                "symbol": "PRIME"
+            },
+            {
+                "assetId": "777777",
+                "symbol": "DEFI"
+            },
+            {
+                "assetId": "22",
+                "symbol": "STH"
+            },
+            {
+                "assetId": "777",
+                "symbol": "GOD"
+            },
+            {
+                "assetId": "567",
+                "symbol": "CHRWNA"
+            },
+            {
+                "assetId": "68",
+                "symbol": "ADVERT"
+            },
+            {
+                "assetId": "24",
+                "symbol": "test"
+            },
+            {
+                "assetId": "90",
+                "symbol": "SATS"
+            },
+            {
+                "assetId": "80",
+                "symbol": "BIT"
+            },
+            {
+                "assetId": "8",
+                "symbol": "RMRK"
+            },
+            {
+                "assetId": "45",
+                "symbol": "CRIB"
+            },
+            {
+                "assetId": "841",
+                "symbol": "YAYOI"
+            },
+            {
+                "assetId": "5201314",
+                "symbol": "belove"
+            },
+            {
+                "assetId": "1234",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "1420",
+                "symbol": "HYDR"
+            },
+            {
+                "assetId": "1000",
+                "symbol": "SPARK"
+            },
+            {
+                "assetId": "223",
+                "symbol": "BILL"
+            },
+            {
+                "assetId": "60",
+                "symbol": "GAV"
+            },
+            {
+                "assetId": "80817",
+                "symbol": "FRALEY"
+            },
+            {
+                "assetId": "1",
+                "symbol": "L T"
+            },
+            {
+                "assetId": "12",
+                "symbol": "BUSD"
+            },
+            {
+                "assetId": "12345",
+                "symbol": "DREX"
+            },
+            {
+                "assetId": "3",
+                "symbol": "Meow"
+            },
+            {
+                "assetId": "55",
+                "symbol": "MTS"
+            },
+            {
+                "assetId": "1337",
+                "symbol": "TIP"
+            },
+            {
+                "assetId": "666",
+                "symbol": "BAD"
+            },
+            {
+                "assetId": "88",
+                "symbol": "BTC"
+            },
+            {
+                "assetId": "17",
+                "symbol": "MEME"
+            },
+            {
+                "assetId": "598",
+                "symbol": "EREN"
+            },
+            {
+                "assetId": "25",
+                "symbol": "BABE"
+            },
+            {
+                "assetId": "69",
+                "symbol": "NICE"
+            },
+            {
+                "assetId": "23",
+                "symbol": "KOJO"
+            },
+            {
+                "assetId": "19840",
+                "symbol": "USDt"
+            },
+            {
+                "assetId": "37",
+                "symbol": "MNCH"
+            },
+            {
+                "assetId": "759",
+                "symbol": "bLd"
+            },
+            {
+                "assetId": "91",
+                "symbol": "TMJ"
+            },
+            {
+                "assetId": "1225",
+                "symbol": "GOD"
+            },
+            {
+                "assetId": "64",
+                "symbol": "oh!"
+            },
+            {
+                "assetId": "520",
+                "symbol": "0xe299a5e299a5e299a5"
+            },
+            {
+                "assetId": "9",
+                "symbol": "TOT"
+            },
+            {
+                "assetId": "888",
+                "symbol": "LUCK"
+            },
+            {
+                "assetId": "911",
+                "symbol": "911"
+            },
+            {
+                "assetId": "214",
+                "symbol": "LOVE"
+            },
+            {
+                "assetId": "345",
+                "symbol": "345"
+            },
+            {
+                "assetId": "1441",
+                "symbol": "SPOT"
+            },
+            {
+                "assetId": "80816",
+                "symbol": "RUEPP"
+            }
+        ]
+    },
+    "SubsocialX": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "SUB"
+        ],
+        "otherAssets": []
+    },
+    "DataHighway": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "DHX"
+        ],
+        "otherAssets": []
+    },
+    "Turing": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "TUR"
+        ],
+        "otherAssets": [
+            {
+                "assetId": "7",
+                "symbol": "PHA"
+            },
+            {
+                "assetId": "5",
+                "symbol": "HKO"
+            },
+            {
+                "assetId": "1",
+                "symbol": "KSM"
+            },
+            {
+                "assetId": "2",
+                "symbol": "AUSD"
+            },
+            {
+                "assetId": "0",
+                "symbol": "TUR"
+            },
+            {
+                "assetId": "6",
+                "symbol": "SKSM"
+            },
+            {
+                "assetId": "3",
+                "symbol": "KAR"
+            },
+            {
+                "assetId": "4",
+                "symbol": "LKSM"
+            }
+        ]
+    },
+    "Zeitgeist": {
+        "relayChainAssetSymbol": "KSM",
+        "nativeAssets": [
+            "ZTG"
+        ],
+        "otherAssets": []
+    }
+}

--- a/src/pallets/assets/assets.test.ts
+++ b/src/pallets/assets/assets.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { nodeNames } from '../../maps/consts'
+import { getAllAssetsSymbols, getAssetId, getAssetsObject, getNativeAssets, getOtherAssets, getRelayChainSymbol } from './assets'
+
+describe('getAssetsObject', () => {
+  it('should return assets object for all nodes', () => {
+    nodeNames.forEach((node) => {
+      const assets = getAssetsObject(node)
+      expect(assets).toEqual(expect.objectContaining({
+        relayChainAssetSymbol: expect.any(String),
+        nativeAssets: expect.any(Array),
+        otherAssets: expect.any(Array)
+      }))
+    })
+  })
+})
+
+describe('getAssetId', () => {
+  it('should return id of BTC from statemine', () => {
+    const assetId = getAssetId('Statemine', 'BTC')
+    expect(assetId).toEqual('9999')
+  })
+
+  it('should return null for not existing assetId', () => {
+    const assetId = getAssetId('Statemine', 'BTG')
+    expect(assetId).toBeNull()
+  })
+})
+
+describe('getRelayChainSymbol', () => {
+  it('should return relay chain currency symbol for Statemine', () => {
+    const assetId = getRelayChainSymbol('Statemine')
+    expect(assetId).toEqual('KSM')
+  })
+  it('should return relay chain currency symbol for Statemint', () => {
+    const assetId = getRelayChainSymbol('Statemint')
+    expect(assetId).toEqual('DOT')
+  })
+  it('should return relay chain currency symbol for all nodes', () => {
+    nodeNames.forEach((node) => {
+      const assetId = getRelayChainSymbol(node)
+      expect(assetId).toBeTypeOf('string')
+    })
+  })
+})
+
+describe('getNativeAssets', () => {
+  it('should return native assets for all nodes except Sora', () => {
+    nodeNames.forEach((node) => {
+      const assets = getNativeAssets(node)
+      if (node === 'Sora') {
+        expect(assets.length).toEqual(0)
+      } else {
+        expect(assets.length).toBeGreaterThan(0)
+        assets.forEach(asset => expect(asset).toBeTypeOf('string'))
+      }
+    })
+  })
+})
+
+describe('getOtherAssets', () => {
+  it('should return other assets or empty array for all nodes', () => {
+    nodeNames.forEach((node) => {
+      const assets = getOtherAssets(node)
+      expect(assets).toBeInstanceOf(Array)
+    })
+  })
+})
+
+describe('getAllAssetsSymbols', () => {
+  it('should return all assets symbols for all nodes', () => {
+    nodeNames.forEach((node) => {
+      const assets = getAllAssetsSymbols(node)
+      expect(assets).toBeInstanceOf(Array)
+      assets.forEach(asset => expect(asset).toBeTypeOf('string'))
+    })
+  })
+})

--- a/src/pallets/assets/assets.ts
+++ b/src/pallets/assets/assets.ts
@@ -1,0 +1,48 @@
+import * as assetsMap from '../../maps/assets.json' assert { type: 'json' }
+import { TAssetJsonMap, TNode } from '../../types'
+
+const assetsMapJson = assetsMap as TAssetJsonMap
+
+function hasAssetsInfo(node: string) {
+  return Object.prototype.hasOwnProperty.call(assetsMapJson, node)
+}
+
+function getAssetsInfo(node: TNode) {
+  return assetsMapJson[node]
+}
+
+export function getAssetsObject(node: TNode) {
+  if (!hasAssetsInfo(node)) { return null }
+  return getAssetsInfo(node)
+}
+
+export function getAssetId(node: TNode, symbol: string): string {
+  if (!hasAssetsInfo(node)) { return null }
+  return getAssetsInfo(node).otherAssets.find(o => o.symbol === symbol)?.assetId ?? null
+}
+
+export function getRelayChainSymbol(node: TNode) {
+  if (!hasAssetsInfo(node)) { return null }
+  return getAssetsInfo(node).relayChainAssetSymbol
+}
+
+export function getNativeAssets(node: TNode) {
+  if (!hasAssetsInfo(node)) { return [] }
+  return getAssetsInfo(node).nativeAssets ?? []
+}
+
+export function getOtherAssets(node: TNode) {
+  if (!hasAssetsInfo(node)) { return [] }
+  return getAssetsInfo(node).otherAssets
+}
+
+export function getAllAssetsSymbols(node: TNode) {
+  if (!hasAssetsInfo(node)) { return [] }
+  const { relayChainAssetSymbol, nativeAssets, otherAssets } = getAssetsInfo(node)
+  return [relayChainAssetSymbol, ...nativeAssets, ...otherAssets.map(({ symbol }) => symbol)]
+}
+
+export function hasSupportForAsset(node: TNode, symbol: string) {
+  if (!hasAssetsInfo(node)) { return false }
+  return getAllAssetsSymbols(node).includes(symbol)
+}

--- a/src/pallets/assets/index.ts
+++ b/src/pallets/assets/index.ts
@@ -1,0 +1,1 @@
+export * from './assets'

--- a/src/pallets/xcmPallet/InvalidCurrencyError.ts
+++ b/src/pallets/xcmPallet/InvalidCurrencyError.ts
@@ -1,0 +1,6 @@
+export class InvalidCurrencyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidCurrencyError'
+  }
+}

--- a/src/pallets/xcmPallet/transfer.test.ts
+++ b/src/pallets/xcmPallet/transfer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { createApiInstance } from '../../utils'
+import { InvalidCurrencyError } from './InvalidCurrencyError'
+import { transferParaToRelay } from './transfer'
+
+const fakeAddress = '0x00000000'
+const amount = 1000
+const currencyID = -1
+
+describe('transferParaToRelay', () => {
+  it('should throw an InvalidCurrencyError when passing Acala and UNIT', () => {
+    return createApiInstance('wss://para.f3joule.space')
+      .then((api) => {
+        const t = () => {
+          transferParaToRelay(
+            api,
+            'Acala',
+            'UNIT',
+            currencyID,
+            amount,
+            fakeAddress
+          )
+        }
+        expect(t).toThrowError(InvalidCurrencyError)
+      })
+  })
+  it('should not throw an InvalidCurrencyError when passing Acala and ACA', () => {
+    return createApiInstance('wss://para.f3joule.space')
+      .then((api) => {
+        const t = () => {
+          transferParaToRelay(
+            api,
+            'Acala',
+            'ACA',
+            currencyID,
+            amount,
+            fakeAddress
+          )
+        }
+        expect(t).not.toThrowError(InvalidCurrencyError)
+      })
+  })
+})

--- a/src/pallets/xcmPallet/transfer.ts
+++ b/src/pallets/xcmPallet/transfer.ts
@@ -1,6 +1,8 @@
 import type { ApiPromise } from '@polkadot/api'
 import { Extrinsic, TNode } from '../../types'
 import { handleAddress, selectLimit, getFees, constructXTokens, getAvailableXCMPallet, constructPolkadotXCM, createHeaderPolkadotXCM, createCurrencySpecification } from '../../utils'
+import { hasSupportForAsset } from '../assets'
+import { InvalidCurrencyError } from './InvalidCurrencyError'
 
 export function transferParaToRelay(
   api: ApiPromise,
@@ -9,7 +11,9 @@ export function transferParaToRelay(
   currencyID: number,
   amount: any,
   to: string
-): Extrinsic {
+): Extrinsic | never {
+  if (!hasSupportForAsset(origin, currency)) { throw new InvalidCurrencyError(`Node ${origin} does not support currency ${currency}.`) }
+
   const pallet = getAvailableXCMPallet(origin)
   if (pallet === 'xTokens' || pallet === 'ormlXTokens') {
     return constructXTokens(
@@ -41,7 +45,9 @@ export function transferParaToPara(
   currencyID: number,
   amount: any,
   to: string
-): Extrinsic {
+): Extrinsic | never {
+  if (!hasSupportForAsset(origin, currency)) { throw new InvalidCurrencyError(`Node ${origin} does not support currency ${currency}.`) }
+
   const pallet = getAvailableXCMPallet(origin)
   if (pallet === 'xTokens' || pallet === 'ormlXTokens') {
     return constructXTokens(

--- a/src/scripts/updateAssets.ts
+++ b/src/scripts/updateAssets.ts
@@ -1,0 +1,251 @@
+import { ApiPromise, WsProvider } from '@polkadot/api'
+import { TAssetJsonMap, TNode, TNodeAssets } from '../types'
+import { getNodeDetails, getNodeEndpointOption } from '../utils'
+
+const ASSETS_MAP_JSON_PATH = './src/maps/assets.json'
+
+type NodeToAssetModuleMap = Record<TNode, string | null>
+
+const nodeToQuery: NodeToAssetModuleMap = {
+  // Chain state query: <module>.<section> for assets metadata
+  Acala: 'assetRegistry.assetMetadatas',
+  Astar: 'assets.metadata',
+  BifrostPolkadot: null, // Has no foreign assets. Native assets are fetched directly from state.getMetadata()
+  Bitgreen: null, // No assets metadata query
+  Centrifuge: 'ormlAssetRegistry.metadata',
+  Clover: 'assets.metadata',
+  ComposableFinance: null, // No assets metadata query
+  Darwinia: null, // No assets metadata query
+  Efinity: null, // Assets query returns empty array
+  Equilibrium: null, // Has eqAssets state query but there are only ids, no symbols
+  HydraDX: null, // Assets query returns empty array
+  Interlay: 'assetRegistry.metadata',
+  Kilt: null, // No assets metadata query
+  Kapex: null, // No assets metadata query
+  Kylin: 'assets.metadata',
+  Litentry: null, // Assets query returns empty array
+  Moonbeam: 'assets.metadata',
+  OriginTrail: 'assets.metadata',
+  Parallel: 'assets.metadata',
+  Phala: 'assets.metadata',
+  Statemint: 'assets.metadata',
+  Unique: null, // No assets metadata query
+  Altair: null, // Assets query returns empty array
+  Amplitude: null, // No assets metadata query
+  Bajun: null, // No assets metadata query
+  Basilisk: 'assetRegistry.assetMetadataMap',
+  BifrostKusama: null, // Has no foreign assets created yet
+  Calamari: 'assets.metadata',
+  Crab: null, // No assets metadata query
+  CrustShadow: 'assets.metadata',
+  Dorafactory: null, // No assets metadata query
+  Encointer: null, // No assets metadata query
+  GM: null, // No assets metadata query
+  Imbue: null, // Assets query returns empty array
+  Integritee: null, // No assets metadata query
+  InvArchTinker: null, // Assets query returns empty array
+  Kico: 'currencies.dicoAssetsInfo',
+  Kabocha: null, // No assets metadata query
+  Karura: 'assetRegistry.assetMetadatas',
+  Khala: 'assets.metadata',
+  Kintsugi: 'assetRegistry.metadata',
+  Listen: 'currencies.listenAssetsInfo',
+  Litmus: null, // Assets query returns empty array
+  Mangata: 'assetRegistry.metadata',
+  Moonriver: 'assets.metadata',
+  ParallelHeiko: 'assets.metadata',
+  Picasso: null, // Assets query returns empty array
+  Pichiu: 'assets.metadata',
+  Pioneer: null, // Assets query returns empty array
+  Quartz: null, // No assets metadata query
+  Robonomics: 'assets.metadata',
+  Sora: null, // No assets metadata query
+  Shiden: 'assets.metadata',
+  Snow: 'assets.metadata',
+  Statemine: 'assets.metadata',
+  SubsocialX: null, // No assets metadata query
+  DataHighway: 'assets.metadata',
+  Turing: 'assetRegistry.metadata',
+  Zeitgeist: null // No assets metadata query
+}
+
+const fetchNativeAssets = async (api: ApiPromise) => {
+  const propertiesRes = await api.rpc.system.properties()
+  return propertiesRes.toHuman().tokenSymbol as string[]
+}
+
+const fetchBifrostNativeAssets = async (api: ApiPromise): Promise<string[]> => {
+  const res = await api.rpc.state.getMetadata()
+  const TYPE_ID = 114
+  return res.asLatest.lookup.types.at(TYPE_ID).type.def.asVariant.variants.map(k => k.name.toHuman())
+}
+
+const fetchOtherAssets = async (api: ApiPromise, query: string) => {
+  const [module, section] = query.split('.')
+  const res = await api.query[module][section].entries()
+  return res.map(([{ args: [era] }, value]) => ({
+    assetId: era.toString(),
+    symbol: (value.toHuman() as any).symbol
+  }))
+}
+
+const fetchOtherAssetsCentrifuge = async (api: ApiPromise, query: string) => {
+  const [module, section] = query.split('.')
+  const res = await api.query[module][section].entries()
+  return res.filter(([{ args: [era] }]) => !Object.prototype.hasOwnProperty.call(era.toHuman(), 'NativeAssetId'))
+    .map(([{ args: [era] }, value]) => ({
+      assetId: Object.values(era.toHuman())[0], symbol: (value.toHuman() as any).symbol
+    }))
+}
+
+const fetchOtherAssetsType2 = async (api: ApiPromise, query: string) => {
+  const [module, section] = query.split('.')
+  const res = await api.query[module][section].entries()
+  return res.map(([{ args: [era] }, value]) => ({
+    assetId: era.toString(),
+    symbol: (value.toHuman() as any).metadata.symbol
+  }))
+}
+
+const fetchAssetsType2 = async (api: ApiPromise, query: string): Promise<Partial<TNodeAssets>> => {
+  const [module, section] = query.split('.')
+  const res = await api.query[module][section].entries()
+
+  const nativeAssets = res
+    .filter(([{ args: [era] }]) => Object.prototype.hasOwnProperty.call(era.toHuman(), 'NativeAssetId'))
+    .map(([, value]) => (value.toHuman() as any).symbol)
+
+  const otherAssets = res
+    .filter(([{ args: [era] }]) => !Object.prototype.hasOwnProperty.call(era.toHuman(), 'NativeAssetId'))
+    .map(([{ args: [era] }, value]) => ({
+      assetId: Object.values(era.toHuman())[0], symbol: (value.toHuman() as any).symbol
+    }))
+
+  return { nativeAssets, otherAssets }
+}
+
+const fetchNodeAssets = async (node: TNode, api: ApiPromise, query: string): Promise<Partial<TNodeAssets>> => {
+  // Different format of data
+  if (node === 'Acala' || node === 'Karura') {
+    const assets = await fetchAssetsType2(api, query)
+    await api.disconnect()
+    return assets
+  }
+
+  // Different format of data
+  if (node === 'Centrifuge') {
+    const nativeAssets = await fetchNativeAssets(api) ?? []
+    const otherAssets = query ? await fetchOtherAssetsCentrifuge(api, query) : []
+    await api.disconnect()
+    return {
+      nativeAssets,
+      otherAssets
+    }
+  }
+
+  if (node === 'BifrostPolkadot') {
+    const nativeAssets = await fetchBifrostNativeAssets(api) ?? []
+    await api.disconnect()
+    return {
+      nativeAssets,
+      otherAssets: []
+    }
+  }
+
+  const nativeAssets = await fetchNativeAssets(api) ?? []
+
+  const fetcher = node === 'Kico' || node === 'Listen' ? fetchOtherAssetsType2 : fetchOtherAssets
+  const otherAssets = query ? await fetcher(api, query) : []
+
+  await api.disconnect()
+
+  return {
+    nativeAssets,
+    otherAssets
+  }
+}
+
+const TIMEOUT_MS = 60000
+
+const fetchNodeAssetsWithTimeout = (node: TNode, wsUrl: string, query: string): Promise<Partial<TNodeAssets>> => {
+  return new Promise((resolve, reject) => {
+    const wsProvider = new WsProvider(wsUrl)
+
+    setTimeout(() => {
+      wsProvider.disconnect()
+      reject(new Error('Timed out'))
+    }, TIMEOUT_MS)
+
+    ApiPromise
+      .create({ provider: wsProvider })
+      .then(api => fetchNodeAssets(node, api, query))
+      .then(resolve)
+  })
+}
+
+const fetchNodeAssetsTryMultipleProviders = async (node: TNode, providers: string[], query: string): Promise<Partial<TNodeAssets> | null> => {
+  for (const provider of providers) {
+    try {
+      console.log(`Trying ${provider}...`)
+      return await fetchNodeAssetsWithTimeout(node, provider, query)
+    } catch (e) {
+      console.log(`Error fetching assets from ${provider}. Trying from another RPC endpoint`)
+    }
+  }
+  console.error(`Assets for ${node} could not be fetched from any endpoint`)
+  return null
+}
+
+const getNodeProviders = (node: TNode) => {
+  const { providers } = getNodeEndpointOption(node)
+  const providersArr = Object.values(providers)
+
+  // TODO: Remove this when lib @polkadot/apps-config releases an update
+  if (node === 'SubsocialX') { providersArr.unshift('wss://para.f3joule.space') } else if (node === 'Bitgreen') { providersArr.unshift('wss://mainnet.bitgreen.org') }
+
+  return providersArr
+}
+
+const fetchAssets = (node: TNode, query: string): Promise<Partial<TNodeAssets> | null> => {
+  const providers = getNodeProviders(node)
+  return fetchNodeAssetsTryMultipleProviders(node, providers, query)
+}
+
+const fetchAllNodesAssets = async (assetMap: NodeToAssetModuleMap, assetsMapJson: any) => {
+  const output: TAssetJsonMap = JSON.parse(JSON.stringify(assetsMapJson))
+  for (const [node, query] of Object.entries(assetMap)) {
+    const nodeName = node as TNode
+    console.log(`Fetching assets for ${nodeName}...`)
+
+    const newData = await fetchAssets(nodeName, query)
+    const isError = newData === null
+    const oldData = Object.prototype.hasOwnProperty.call(output, nodeName) ? output[nodeName] : null
+
+    // In case we cannot fetch assets for some node. Keep existing data
+    output[nodeName] = {
+      relayChainAssetSymbol: getNodeDetails(nodeName).type === 'polkadot' ? 'DOT' : 'KSM',
+      nativeAssets: isError && oldData ? oldData.nativeAssets : newData?.nativeAssets ?? [],
+      otherAssets: isError && oldData ? oldData.otherAssets : newData?.otherAssets ?? []
+    }
+  }
+  return output
+}
+
+const readAssetsJson = async () => {
+  const { readFileSync } = await import('fs')
+  try {
+    return JSON.parse(readFileSync(ASSETS_MAP_JSON_PATH, 'utf8'))
+  } catch (e) {
+    return {}
+  }
+}
+
+(async () => {
+  if (typeof process !== 'object') { throw new TypeError('This script can only be executed in Node.JS environment') }
+  const assetsJson = await readAssetsJson()
+  const data = await fetchAllNodesAssets(nodeToQuery, assetsJson)
+  const { writeFileSync } = await import('fs')
+  writeFileSync(ASSETS_MAP_JSON_PATH, JSON.stringify(data, null, 4))
+  console.log('Successfuly fetched all assets')
+  process.exit()
+})()

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,3 +13,13 @@ export type TNodeDetails = {
     type: TRelayChainType
 }
 export type TNode = typeof nodeNames[number];
+export type TAssetDetails = {
+    assetId: string;
+    symbol: string;
+}
+export type TNodeAssets = {
+    relayChainAssetSymbol: 'KSM' | 'DOT';
+    nativeAssets: string[];
+    otherAssets: TAssetDetails[];
+}
+export type TAssetJsonMap = Record<TNode, TNodeAssets>

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { nodeNames } from './maps/consts'
+import { getNodeDetails, getNodeEndpointOption, getNodeParaId } from './utils'
+
+describe('getNodeParaId', () => {
+  it('should return numeric value for all nodes', () => {
+    nodeNames.forEach((node) => {
+      const paraId = getNodeParaId(node)
+      expect(paraId).toBeTypeOf('number')
+    })
+  })
+})
+
+describe('getNodeDetails', () => {
+  it('should return node detail for all nodes', () => {
+    nodeNames.forEach((node) => {
+      const details = getNodeDetails(node)
+      expect(details).toBeDefined()
+      expect(details.name).toBeTypeOf('string')
+      expect(['polkadot', 'kusama']).toContain(details.type)
+    })
+  })
+})
+
+describe('getNodeEndpointOption', () => {
+  it('should return endpoint option for all nodes', () => {
+    nodeNames.forEach((node) => {
+      const option = getNodeEndpointOption(node)
+      expect(option).toBeDefined()
+      expect(option).toHaveProperty('providers')
+      expect(Object.keys(option.providers).length).toBeGreaterThan(0)
+      expect(option).toHaveProperty('paraId')
+      expect(option.paraId).toBeTypeOf('number')
+    })
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
-import type { ApiPromise } from '@polkadot/api'
+import { ApiPromise, WsProvider } from '@polkadot/api'
 import { ethers } from 'ethers'
-import { prodRelayPolkadot, prodRelayKusama } from '@polkadot/apps-config'
+import { prodRelayPolkadot, prodRelayKusama } from '@polkadot/apps-config/endpoints'
 import { nodeToPallet } from './maps/PalletMap'
 import { Extrinsic, TNode } from './types'
 import { nodes } from './maps/consts'
@@ -606,12 +606,21 @@ export function constructPolkadotXCM(api: ApiPromise, origin: TNode, header: any
 }
 
 export function getNodeDetails(node: TNode) {
-  if (!Object.prototype.hasOwnProperty.call(nodeToPallet, node)) { return null }
   return nodes[node]
 }
 
-export function getNodeParaId(node: TNode) {
-  const { name, type } = getNodeDetails(node)
+export function getNodeEndpointOption(node: TNode) {
+  const { type, name } = getNodeDetails(node)
   const { linked } = type === 'polkadot' ? prodRelayPolkadot : prodRelayKusama
-  return linked.find(o => o.info === name)?.paraId
+  return linked?.find(o => o.info === name)
+}
+
+export function getNodeParaId(node: TNode) {
+  const option = getNodeEndpointOption(node)
+  return option?.paraId ?? null
+}
+
+export async function createApiInstance(wsUrl: string) {
+  const wsProvider = new WsProvider(wsUrl)
+  return await ApiPromise.create({ provider: wsProvider })
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,0 @@
-import { describe } from 'vitest'
-/* eslint-disable */
-describe.skip()
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Node",
     "esModuleInterop": true,
     "noImplicitAny": true,
+    "resolveJsonModule": true
   },
   "include": [
     "src"


### PR DESCRIPTION

This PR will implement support for checking asset compatibility through asset pallet.
- Devs are now able to pull new assets with command `pnpm updateAssets`
- Devs can pull assets from SDK via following commands:
- 1. function `getAssetsObject(node: TNode)` - Returns assets object from assets.json for particular node including information about native and foreign assets.
- 2. function `getAssetId(node: TNode, symbol: string)` - Returns foreign assetId for particular node and asset symbol.
- 3. function `getRelayChainSymbol(node: TNode)` - Returns symbol of the relay chain for particular node. Either "DOT" or "KSM".
- 4. function `getNativeAssets(node: TNode)` Returns string array of native assets symbols for particular node.
- 5. function `getOtherAssets(node: TNode)` Returns object array of foreign assets for particular node. Each object has symbol and assetId property.
- 6. function `getAllAssetsSymbols(node: TNode)` Returns string array of all assets symbols. (native and foreign assets are merged to a single array).
- 7. function `hasSupportForAsset(node: TNode, symbol: string)` Checks if node supports particular asset. (Both native and foreign assets are searched). Returns boolean.
